### PR TITLE
Add support for command-based authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ For more flexible configuration, use the overload that takes `KubeClientOptions`
 KubeApiClient client = KubeApiClient.Create(new KubeClientOptions
 {
     ApiEndPoint = new Uri("http://localhost:8001"),
+    AuthStrategy = KubeAuthStrategy.BearerToken,
     AccessToken = "my-access-token",
     AllowInsecure = true // Don't validate server certificate
 });
@@ -95,6 +96,7 @@ void ConfigureServices(IServiceCollection services)
     services.AddKubeClient(new KubeClientOptions
     {
         ApiEndPoint = new Uri("http://localhost:8001"),
+        AuthStrategy = KubeAuthStrategy.BearerToken,
         AccessToken = "my-access-token",
         AllowInsecure = true // Don't validate server certificate
     });
@@ -110,6 +112,7 @@ void ConfigureServices(IServiceCollection services)
     services.AddKubeClientOptions("my-cluster", clientOptions =>
     {
         clientOptions.ApiEndPoint = new Uri("http://localhost:8001");
+        clientOptions.AuthStrategy = KubeAuthStrategy.BearerToken;
         clientOptions.AccessToken = "my-access-token";
         clientOptions.AllowInsecure = true; // Don't validate server certificate
     });
@@ -119,6 +122,7 @@ void ConfigureServices(IServiceCollection services)
     services.AddKubeClient("my-cluster", clientOptions =>
     {
         clientOptions.ApiEndPoint = new Uri("http://localhost:8001");
+        clientOptions.AuthStrategy = KubeAuthStrategy.BearerToken;
         clientOptions.AccessToken = "my-access-token";
         clientOptions.AllowInsecure = true; // Don't validate server certificate
     });

--- a/src/KubeClient.Extensions.KubeConfig/K8sConfig.cs
+++ b/src/KubeClient.Extensions.KubeConfig/K8sConfig.cs
@@ -174,6 +174,22 @@ namespace KubeClient
             kubeClientOptions.AllowInsecure = targetCluster.Config.AllowInsecure;
             kubeClientOptions.CertificationAuthorityCertificate = targetCluster.Config.GetCACertificate();
             kubeClientOptions.AccessToken = targetUser.Config.GetRawToken();
+            
+            AuthProviderConfig authProvider = targetUser.Config.AuthProvider;
+            if (authProvider != null)
+            {
+                if (authProvider.Config.TryGetValue("cmd-path", out object accessTokenCommand))
+                    kubeClientOptions.AccessTokenCommand = (string)accessTokenCommand;
+
+                if (authProvider.Config.TryGetValue("cmd-args", out object accessTokenCommandArguments))
+                    kubeClientOptions.AccessTokenCommandArguments = (string)accessTokenCommandArguments;
+
+                if (authProvider.Config.TryGetValue("token-key", out object accessTokenSelector))
+                    kubeClientOptions.AccessTokenSelector = (string)accessTokenSelector;
+
+                if (authProvider.Config.TryGetValue("expiry-key", out object accessTokenExpirySelector))
+                    kubeClientOptions.AccessTokenExpirySelector = (string)accessTokenExpirySelector;
+            }
 
             return kubeClientOptions;
         }

--- a/src/KubeClient.Extensions.KubeConfig/Models/AuthProviderConfig.cs
+++ b/src/KubeClient.Extensions.KubeConfig/Models/AuthProviderConfig.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using YamlDotNet.Serialization;
+
+namespace KubeClient.Extensions.KubeConfig.Models
+{
+    /// <summary>
+    ///     Configuration for a K8s client authentication provider.
+    /// </summary>
+    public class AuthProviderConfig
+    {
+        /// <summary>
+        ///     The provider name.
+        /// </summary>
+        [YamlMember(Alias = "name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        ///     The raw provider configuration.
+        /// </summary>
+        [YamlMember(Alias = "config")]
+        public Dictionary<string, object> Config { get; set; } = new Dictionary<string, object>();
+    }
+}

--- a/src/KubeClient.Extensions.KubeConfig/Models/UserIdentityConfig.cs
+++ b/src/KubeClient.Extensions.KubeConfig/Models/UserIdentityConfig.cs
@@ -18,6 +18,12 @@ namespace KubeClient.Extensions.KubeConfig.Models
         public string Token { get; set; }
 
         /// <summary>
+        ///     Optional configuration for an authentication provider.
+        /// </summary>
+        [YamlMember(Alias = "auth-provider")]
+        public AuthProviderConfig AuthProvider { get; set; }
+
+        /// <summary>
         ///     A file containing the PEM-encoded client certificate to use.
         /// </summary>
         [YamlMember(Alias = "client-certificate")]

--- a/src/KubeClient/KubeApiClient.cs
+++ b/src/KubeClient/KubeApiClient.cs
@@ -136,7 +136,18 @@ namespace KubeClient
             if (!String.IsNullOrWhiteSpace(options.AccessToken))
             {
                 clientBuilder = clientBuilder.AddHandler(
-                    () => new BearerTokenHandler(options.AccessToken)
+                    () => new StaticBearerTokenHandler(options.AccessToken)
+                );
+            }
+            else if (!String.IsNullOrWhiteSpace(options.AccessTokenCommand))
+            {
+                clientBuilder = clientBuilder.AddHandler(
+                    () => new CommandBearerTokenHandler(
+                        accessTokenCommand: options.AccessTokenCommand,
+                        accessTokenCommandArguments: options.AccessTokenCommandArguments,
+                        accessTokenSelector: options.AccessTokenSelector,
+                        accessTokenExpirySelector: options.AccessTokenExpirySelector
+                    )
                 );
             }
 

--- a/src/KubeClient/KubeApiClient.cs
+++ b/src/KubeClient/KubeApiClient.cs
@@ -256,6 +256,7 @@ namespace KubeClient
             return Create(new KubeClientOptions
             {
                 ApiEndPoint = new Uri(apiEndPoint),
+                AuthStrategy = KubeAuthStrategy.BearerToken,
                 AccessToken = accessToken,
                 CertificationAuthorityCertificate = expectServerCertificate
             }, loggerFactory);
@@ -284,6 +285,7 @@ namespace KubeClient
             return Create(new KubeClientOptions
             {
                 ApiEndPoint = new Uri(apiEndPoint),
+                AuthStrategy = KubeAuthStrategy.ClientCertificate,
                 ClientCertificate = clientCertificate,
                 CertificationAuthorityCertificate = expectServerCertificate
             }, loggerFactory);

--- a/src/KubeClient/KubeClient.csproj
+++ b/src/KubeClient/KubeClient.csproj
@@ -11,6 +11,7 @@
       <PackageReference Include="HTTPlease.Formatters.Json" Version="$(PackageVersion_HTTPlease)" />
       <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="1.1.2" />
       <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+      <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
       <PackageReference Include="System.Reactive" Version="3.1.1" />
       <PackageReference Include="System.ValueTuple" Version="4.4.0" />
       <PackageReference Include="YamlDotNet" Version="4.2.1" />

--- a/src/KubeClient/KubeClientOptions.cs
+++ b/src/KubeClient/KubeClientOptions.cs
@@ -48,6 +48,26 @@ namespace KubeClient
         public string AccessToken { get; set; }
 
         /// <summary>
+        ///     The command used to generate an access token for authenticating to the Kubernetes API.
+        /// </summary>
+        public string AccessTokenCommand { get; set; }
+
+        /// <summary>
+        ///     The command arguments used to generate an access token for authenticating to the Kubernetes API.
+        /// </summary>
+        public string AccessTokenCommandArguments { get; set; }
+
+        /// <summary>
+        ///     The Go-style selector used to retrieve the access token from the command output.
+        /// </summary>
+        public string AccessTokenSelector { get; set; }
+
+        /// <summary>
+        ///     The Go-style selector used to retrieve the access token's expiry date/time from the command output.
+        /// </summary>
+        public string AccessTokenExpirySelector { get; set; }
+
+        /// <summary>
         ///     The client certificate used to authenticate to the Kubernetes API.
         /// </summary>
         public X509Certificate2 ClientCertificate { get; set; }

--- a/src/KubeClient/KubeClientOptions.cs
+++ b/src/KubeClient/KubeClientOptions.cs
@@ -75,12 +75,12 @@ namespace KubeClient
         /// <summary>
         ///     The initial token expiry used to authenticate to the Kubernetes API.
         /// </summary>
-        public string InitialTokenExpiry { get; set; }
+        public DateTime? InitialTokenExpiryUtc { get; set; }
         
         /// <summary>
         ///     The strategy used for authenticating to the Kubernetes API.
         /// </summary>
-        public AuthStrategy AuthStrategy { get; set; }
+        public KubeAuthStrategy AuthStrategy { get; set; }
 
         /// <summary>
         ///     The client certificate used to authenticate to the Kubernetes API.
@@ -187,10 +187,29 @@ namespace KubeClient
         }
     }
 
-    public enum AuthStrategy
+    /// <summary>
+    ///     Represents a strategy for authenticating to the Kubernetes API.
+    /// </summary>
+    public enum KubeAuthStrategy
     {
+        /// <summary>
+        ///     No authentication (e.g. via "kubectl proxy").
+        /// </summary>
         None,
-        StaticBearerToken,
-        RefreshableBearerToken
+
+        /// <summary>
+        ///     Client certificate (i.e. mutual SSL) authentication.
+        /// </summary>
+        ClientCertificate,
+
+        /// <summary>
+        ///     A pre-defined (static) bearer token.
+        /// </summary>
+        BearerToken,
+
+        /// <summary>
+        ///     A bearer token obtained by an authentication provider (i.e. running an external command).
+        /// </summary>
+        BearerTokenProvider
     }
 }

--- a/src/KubeClient/KubeClientOptions.cs
+++ b/src/KubeClient/KubeClientOptions.cs
@@ -181,6 +181,7 @@ namespace KubeClient
             return new KubeClientOptions
             {
                 ApiEndPoint = new Uri(apiEndPoint),
+                AuthStrategy = KubeAuthStrategy.BearerToken,
                 AccessToken = accessToken,
                 CertificationAuthorityCertificate = kubeCACertificate
             };

--- a/src/KubeClient/MessageHandlers/BearerTokenHandler.cs
+++ b/src/KubeClient/MessageHandlers/BearerTokenHandler.cs
@@ -47,11 +47,11 @@ namespace KubeClient.MessageHandlers
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
             
-            string token = await GetTokenAsync(cancellationToken);
+            string token = await GetTokenAsync(cancellationToken).ConfigureAwait(false);
 
             request.Headers.Authorization = new AuthenticationHeaderValue(scheme: "Bearer", parameter: token);
 
-            return await base.SendAsync(request, cancellationToken);
+            return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/KubeClient/MessageHandlers/BearerTokenHandler.cs
+++ b/src/KubeClient/MessageHandlers/BearerTokenHandler.cs
@@ -7,29 +7,28 @@ using System.Threading.Tasks;
 namespace KubeClient.MessageHandlers
 {
     /// <summary>
-    ///     HTTP message handler that adds a bearer token to outgoing requests.
+    ///     The base class for HTTP message handlers that add a bearer token to outgoing requests.
     /// </summary>
-    public class BearerTokenHandler
+    public abstract class BearerTokenHandler
         : DelegatingHandler
     {
         /// <summary>
-        ///     The bearer token added to outgoing requests.
-        /// </summary>
-        readonly string _token;
-
-        /// <summary>
         ///     Create a new <see cref="BearerTokenHandler"/>.
         /// </summary>
-        /// <param name="token">
-        ///     The bearer token added to outgoing requests.
-        /// </param>
-        public BearerTokenHandler(string token)
+        protected BearerTokenHandler()
         {
-            if (String.IsNullOrWhiteSpace(token))
-                throw new ArgumentException("Argument cannot be null, empty, or entirely composed of whitespace: 'token'.", nameof(token));
-            
-            _token = token;
         }
+
+        /// <summary>
+        ///     Obtain a bearer token to use for authentication.
+        /// </summary>
+        /// <param name="cancellationToken">
+        ///     An optional <see cref="CancellationToken"/> that can be used to cancel the operation.
+        /// </param>
+        /// <returns>
+        ///     The access token.
+        /// </returns>
+        protected abstract Task<string> GetTokenAsync(CancellationToken cancellationToken);
 
         /// <summary>
         ///     Asynchronously process an HTTP request.
@@ -43,14 +42,16 @@ namespace KubeClient.MessageHandlers
         /// <returns>
         ///     The incoming response message.
         /// </returns>
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected sealed override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
             
-            request.Headers.Authorization = new AuthenticationHeaderValue(scheme: "Bearer", parameter: _token);
+            string token = await GetTokenAsync(cancellationToken);
 
-            return base.SendAsync(request, cancellationToken);
+            request.Headers.Authorization = new AuthenticationHeaderValue(scheme: "Bearer", parameter: token);
+
+            return await base.SendAsync(request, cancellationToken);
         }
     }
 }

--- a/src/KubeClient/MessageHandlers/CommandBearerTokenHandler.cs
+++ b/src/KubeClient/MessageHandlers/CommandBearerTokenHandler.cs
@@ -21,11 +21,6 @@ namespace KubeClient.MessageHandlers
         : BearerTokenHandler
     {
         /// <summary>
-        ///     The span of time to wait between checks to see if the command's process has terminated.
-        /// </summary>
-        static readonly TimeSpan CommandSpinWaitDelay = TimeSpan.FromMilliseconds(200);
-
-        /// <summary>
         ///     An object used to synchronise access to handler state.
         /// </summary>
         readonly object _stateLock = new object();

--- a/src/KubeClient/MessageHandlers/CommandBearerTokenHandler.cs
+++ b/src/KubeClient/MessageHandlers/CommandBearerTokenHandler.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace KubeClient.MessageHandlers
+{
+    /// <summary>
+    ///     HTTP message handler that runs a command to obtain a bearer token and adds it to outgoing requests.
+    /// </summary>
+    public class CommandBearerTokenHandler
+        : BearerTokenHandler
+    {
+        /// <summary>
+        ///     The command to execute in order to obtain the access token for outgoing requests.
+        /// </summary>
+        readonly string _accessTokenCommand;
+
+        /// <summary>
+        ///     The arguments (if any) for the access-token command.
+        /// </summary>
+        readonly string _accessTokenCommandArguments;
+
+        /// <summary>
+        ///     The JPath-style selector used to retrieve the access token from the command output.
+        /// </summary>
+        readonly string _accessTokenSelector;
+
+        /// <summary>
+        ///     The JPath-style selector used to retrieve the access token's expiry date/time from the command output.
+        /// </summary>
+        readonly string _accessTokenExpirySelector;
+
+        /// <summary>
+        ///     The current access token (if any).
+        /// </summary>
+        string _accessToken;
+
+        /// <summary>
+        ///     The UTC date/time that the access token expires.
+        /// </summary>
+        DateTime _accessTokenExpiresUtc;
+
+        /// <summary>
+        ///     Create a new <see cref="CommandBearerTokenHandler"/>.
+        /// </summary>
+        /// <param name="accessTokenCommand">
+        ///     The command to execute in order to obtain the access token for outgoing requests.
+        /// </param>
+        /// <param name="accessTokenCommandArguments">
+        ///     The arguments (if any) for the access-token command.
+        /// </param>
+        /// <param name="accessTokenSelector">
+        ///     The Go-style selector used to retrieve the access token from the command output.
+        /// </param>
+        /// <param name="accessTokenExpirySelector">
+        ///     The Go-style selector used to retrieve the access token's expiry date/time from the command output.
+        /// </param>
+        public CommandBearerTokenHandler(string accessTokenCommand, string accessTokenCommandArguments, string accessTokenSelector, string accessTokenExpirySelector)
+        {
+            if (String.IsNullOrWhiteSpace(accessTokenCommand))
+                throw new ArgumentException("Argument cannot be null, empty, or entirely composed of whitespace: 'accessTokenCommand'.", nameof(accessTokenCommand));
+
+            if (String.IsNullOrWhiteSpace(accessTokenSelector))
+                throw new ArgumentException("Argument cannot be null, empty, or entirely composed of whitespace: 'accessTokenSelector'.", nameof(accessTokenSelector));
+            
+            if (String.IsNullOrWhiteSpace(accessTokenExpirySelector))
+                throw new ArgumentException("Argument cannot be null, empty, or entirely composed of whitespace: 'accessTokenExpirySelector'.", nameof(accessTokenExpirySelector));
+            
+            _accessTokenCommand = accessTokenCommand;
+            _accessTokenCommandArguments = accessTokenCommandArguments ?? String.Empty;
+            _accessTokenSelector = JPathFromGoSelector(_accessTokenSelector);
+            _accessTokenExpirySelector = JPathFromGoSelector(_accessTokenExpirySelector);
+        }
+
+        /// <summary>
+        ///     Obtain a bearer token to use for authentication.
+        /// </summary>
+        /// <param name="cancellationToken">
+        ///     An optional <see cref="CancellationToken"/> that can be used to cancel the operation.
+        /// </param>
+        /// <returns>
+        ///     The access token.
+        /// </returns>
+        protected override async Task<string> GetTokenAsync(CancellationToken cancellationToken)
+        {
+            if (!String.IsNullOrWhiteSpace(_accessToken) && _accessTokenExpiresUtc > DateTime.UtcNow)
+                return _accessToken;
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            ProcessStartInfo accessTokenCommandInfo = new ProcessStartInfo(_accessTokenCommand, _accessTokenCommandArguments)
+            {
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+
+            using (Process accessTokenCommand = Process.Start(accessTokenCommandInfo))
+            {
+                try
+                {
+                    // Don't block waiting for program to exit.
+                    while (!accessTokenCommand.HasExited)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        await Task.Delay(
+                            TimeSpan.FromMilliseconds(200)
+                        );
+                    }
+
+                    string standardOutput = await accessTokenCommand.StandardOutput.ReadToEndAsync();
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    if (accessTokenCommand.ExitCode != 1)
+                    {
+                        string standardError = await accessTokenCommand.StandardOutput.ReadToEndAsync();
+                        
+                        throw new KubeClientException(
+                            $"Failed to execute access-token command '{_accessTokenCommand} {_accessTokenCommandArguments}'."
+                                + Environment.NewLine
+                                + standardOutput
+                                + Environment.NewLine
+                                + standardError
+                        );
+                    }
+
+                    standardOutput = standardOutput.Trim();
+
+                    // Ensure command output is JSON
+                    JObject outputJson;
+                    try
+                    {
+                        outputJson = JObject.Parse(standardOutput);
+                    }
+                    catch (JsonReaderException invalidJson)
+                    {
+                        throw new KubeClientException($"Failed to parse output of access-token command '{_accessTokenCommand} {_accessTokenCommandArguments}' (not valid JSON).",
+                            innerException: invalidJson
+                        );
+                    }
+
+                    string accessToken = outputJson.SelectToken(_accessTokenSelector)?.Value<string>();
+                    if (accessToken == null)
+                    {
+                        throw new KubeClientException(
+                            $"Failed to find access-token in output of command '{_accessTokenCommand} {_accessTokenCommandArguments}' using JPath selector '{_accessTokenSelector}'."
+                                + Environment.NewLine
+                                + standardOutput
+                        );
+                    }
+
+                    string tokenExpiresUtc = outputJson.SelectToken(_accessTokenExpirySelector)?.Value<string>();
+                    if (tokenExpiresUtc == null)
+                    {
+                        throw new KubeClientException(
+                            $"Failed to find access-token lifetime in output of command '{_accessTokenCommand} {_accessTokenCommandArguments}' using JPath selector '{_accessTokenExpirySelector}'."
+                                + Environment.NewLine
+                                + standardOutput
+                        );
+                    }
+
+                    _accessToken = accessToken;
+                    _accessTokenExpiresUtc = DateTime.ParseExact(tokenExpiresUtc,
+                        format: "yyyy-MM-ddThh:mm:ssZ",
+                        provider: CultureInfo.InvariantCulture,
+                        style: DateTimeStyles.AssumeUniversal
+                    );
+                }
+                catch (OperationCanceledException)
+                {
+                    // Ensure we don't leave the command running if the caller cancels.
+                    if (!accessTokenCommand.HasExited)
+                        accessTokenCommand.Kill();
+
+                    throw;
+                }
+
+                return _accessToken;
+            }
+        }
+
+        /// <summary>
+        ///     Convert a Go-style selector to a JPath-style selector.
+        /// </summary>
+        /// <param name="goSelector">
+        ///     The Go-style selector (e.g. "{.foo.bar}").
+        /// </param>
+        /// <returns>
+        ///     The JPath-style selector (e.g. "$.foo.bar").
+        /// </returns>
+        static string JPathFromGoSelector(string goSelector)
+        {
+            if (String.IsNullOrWhiteSpace(goSelector))
+                throw new ArgumentException("Argument cannot be null, empty, or entirely composed of whitespace: 'goSelector'.", nameof(goSelector));
+
+            string jpath = goSelector;
+            
+            if (jpath[0] == '{' && jpath[jpath.Length - 1] == '}')
+                jpath = jpath.Substring(1, jpath.Length - 2);
+            
+            if (jpath[0] == '.')
+                jpath = '$' + jpath;
+
+            return goSelector;
+        }
+    }
+}

--- a/src/KubeClient/MessageHandlers/CommandBearerTokenHandler.cs
+++ b/src/KubeClient/MessageHandlers/CommandBearerTokenHandler.cs
@@ -48,7 +48,7 @@ namespace KubeClient.MessageHandlers
         /// <summary>
         ///     The UTC date/time that the access token expires.
         /// </summary>
-        DateTime _accessTokenExpiresUtc;
+        DateTime? _accessTokenExpiresUtc;
 
         /// <summary>
         ///     Create a new <see cref="CommandBearerTokenHandler"/>.
@@ -65,7 +65,13 @@ namespace KubeClient.MessageHandlers
         /// <param name="accessTokenExpirySelector">
         ///     The Go-style selector used to retrieve the access token's expiry date/time from the command output.
         /// </param>
-        public CommandBearerTokenHandler(string accessTokenCommand, string accessTokenCommandArguments, string accessTokenSelector, string accessTokenExpirySelector, string initialAccessToken = null, string initialTokenExpiry = null)
+        /// <param name="initialAccessToken">
+        ///     The initial access token (if any) to use for authentication.
+        /// </param>
+        /// <param name="initialTokenExpiryUtc">
+        ///     The UTC date / time the the initial access token (if any) expires.
+        /// </param>
+        public CommandBearerTokenHandler(string accessTokenCommand, string accessTokenCommandArguments, string accessTokenSelector, string accessTokenExpirySelector, string initialAccessToken = null, DateTime? initialTokenExpiryUtc = null)
         {
             if (String.IsNullOrWhiteSpace(accessTokenCommand))
                 throw new ArgumentException("Argument cannot be null, empty, or entirely composed of whitespace: 'accessTokenCommand'.", nameof(accessTokenCommand));
@@ -84,8 +90,7 @@ namespace KubeClient.MessageHandlers
             if (!String.IsNullOrWhiteSpace(initialAccessToken))
                 _accessToken = initialAccessToken;
 
-            if (!String.IsNullOrWhiteSpace(initialTokenExpiry))
-                _accessTokenExpiresUtc = ConvertAccessTokenExpiresUtc(initialTokenExpiry);
+            _accessTokenExpiresUtc = initialTokenExpiryUtc;
         }
 
         /// <summary>
@@ -100,7 +105,7 @@ namespace KubeClient.MessageHandlers
         protected override async Task<string> GetTokenAsync(CancellationToken cancellationToken)
         {
             string accessToken;
-            DateTime accessTokenExpiresUtc;
+            DateTime? accessTokenExpiresUtc;
 
             // Capture snapshot of access token / expiry.
             lock (_stateLock)

--- a/src/KubeClient/MessageHandlers/CommandBearerTokenHandler.cs
+++ b/src/KubeClient/MessageHandlers/CommandBearerTokenHandler.cs
@@ -17,6 +17,11 @@ namespace KubeClient.MessageHandlers
         : BearerTokenHandler
     {
         /// <summary>
+        ///     The span of time to wait between checks to see if the command's process has terminated.
+        /// </summary>
+        static readonly TimeSpan CommandWaitSpinDelay = TimeSpan.FromMilliseconds(200);
+
+        /// <summary>
         ///     The command to execute in order to obtain the access token for outgoing requests.
         /// </summary>
         readonly string _accessTokenCommand;
@@ -111,17 +116,15 @@ namespace KubeClient.MessageHandlers
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
-                        await Task.Delay(
-                            TimeSpan.FromMilliseconds(200)
-                        );
+                        await Task.Delay(CommandWaitSpinDelay).ConfigureAwait(false);
                     }
 
-                    string standardOutput = await accessTokenCommand.StandardOutput.ReadToEndAsync();
+                    string standardOutput = await accessTokenCommand.StandardOutput.ReadToEndAsync().ConfigureAwait(false);
                     cancellationToken.ThrowIfCancellationRequested();
 
                     if (accessTokenCommand.ExitCode != 1)
                     {
-                        string standardError = await accessTokenCommand.StandardOutput.ReadToEndAsync();
+                        string standardError = await accessTokenCommand.StandardOutput.ReadToEndAsync().ConfigureAwait(false);
                         
                         throw new KubeClientException(
                             $"Failed to execute access-token command '{_accessTokenCommand} {_accessTokenCommandArguments}'."

--- a/src/KubeClient/MessageHandlers/StaticBearerTokenHandler.cs
+++ b/src/KubeClient/MessageHandlers/StaticBearerTokenHandler.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace KubeClient.MessageHandlers
+{
+    /// <summary>
+    ///     HTTP message handler that adds a bearer token to outgoing requests.
+    /// </summary>
+    public class StaticBearerTokenHandler
+        : BearerTokenHandler
+    {
+        /// <summary>
+        ///     The bearer token added to outgoing requests.
+        /// </summary>
+        readonly string _token;
+
+        /// <summary>
+        ///     Create a new <see cref="StaticBearerTokenHandler"/>.
+        /// </summary>
+        /// <param name="token">
+        ///     The bearer token added to outgoing requests.
+        /// </param>
+        public StaticBearerTokenHandler(string token)
+        {
+            if (String.IsNullOrWhiteSpace(token))
+                throw new ArgumentException("Argument cannot be null, empty, or entirely composed of whitespace: 'token'.", nameof(token));
+            
+            _token = token;
+        }
+
+        /// <summary>
+        ///     Obtain a bearer token to use for authentication.
+        /// </summary>
+        /// <param name="cancellationToken">
+        ///     An optional <see cref="CancellationToken"/> that can be used to cancel the operation.
+        /// </param>
+        /// <returns>
+        ///     The access token.
+        /// </returns>
+        protected override Task<string> GetTokenAsync(CancellationToken cancellationToken) => Task.FromResult(_token);
+    }
+}

--- a/src/KubeClient/Utilities/ProcessHelper.cs
+++ b/src/KubeClient/Utilities/ProcessHelper.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace KubeClient.Utilities
+{
+    /// <summary>
+    ///     Helper methods for working with a <see cref="Process"/>.
+    /// </summary>
+    static class ProcessHelper
+    {
+        /// <summary>
+        ///     Asynchronously wait for the process to exit.
+        /// </summary>
+        /// <param name="process">
+        ///     The target <see cref="Process"/>.
+        /// </param>
+        /// <returns>
+        ///     The process exit code.
+        /// </returns>
+        public static Task<int> WaitForExitAsync(this Process process)
+        {
+            return process.WaitForExitAsync(CancellationToken.None);
+        }
+        
+        /// <summary>
+        ///     Asynchronously wait for the process to exit.
+        /// </summary>
+        /// <param name="process">
+        ///     The target <see cref="Process"/>.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken"/> that can be used to cancel the wait.
+        /// </param>
+        /// <returns>
+        ///     The process exit code.
+        /// </returns>
+        public static Task<int> WaitForExitAsync(this Process process, CancellationToken cancellationToken)
+        {
+            return process.WaitForExitAsync(cancellationToken, killIfCancelled: false);
+        }
+
+        /// <summary>
+        ///     Asynchronously wait for the process to exit.
+        /// </summary>
+        /// <param name="process">
+        ///     The target <see cref="Process"/>.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken"/> that can be used to cancel the wait.
+        /// </param>
+        /// <param name="killIfCancelled">
+        ///     Kill the process if the <paramref name="cancellationToken"/> is cancelled?
+        /// </param>
+        /// <returns>
+        ///     The process exit code.
+        /// </returns>
+        public static Task<int> WaitForExitAsync(this Process process, CancellationToken cancellationToken, bool killIfCancelled)
+        {
+            if (process == null)
+                throw new ArgumentNullException(nameof(process));
+
+            // Short-circuit: already exited.
+            if (process.HasExited)
+                return Task.FromResult(process.ExitCode);
+            
+            TaskCompletionSource<int> completion = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            
+            cancellationToken.Register(() =>
+            {
+                try
+                {
+                    if (killIfCancelled && !process.HasExited)
+                        process.Kill();
+                }
+                finally
+                {
+                    completion.TrySetCanceled(cancellationToken);
+                }
+            });
+
+            process.Exited += (sender, eventArgs) =>
+            {
+                completion.TrySetResult(process.ExitCode);
+            };
+            process.EnableRaisingEvents = true;
+
+            // Short-circuit: exited while we were hooking event (i.e. race condition).
+            if (process.HasExited)
+                completion.TrySetResult(process.ExitCode);
+
+            return completion.Task;
+        }
+    }
+}


### PR DESCRIPTION
This will remove the need for `kubectl proxy` when using K8s implementations (such as GKE) that use a command-based access token provider.

Implements tintoy/dotnet-kube-client#20.