### PR TITLE
Make DeploymentClientV implement interface

### DIFF
--- a/src/KubeClient/ClientFactoryExtensions.cs
+++ b/src/KubeClient/ClientFactoryExtensions.cs
@@ -56,7 +56,7 @@ namespace KubeClient
         /// <returns>
         ///     The resource client.
         /// </returns>
-        public static DeploymentClientV1 DeploymentsV1(this IKubeApiClient kubeClient)
+        public static IDeploymentClientV1 DeploymentsV1(this IKubeApiClient kubeClient)
         {
             if (kubeClient == null)
                 throw new ArgumentNullException(nameof(kubeClient));
@@ -75,7 +75,7 @@ namespace KubeClient
         /// <returns>
         ///     The resource client.
         /// </returns>
-        public static DeploymentClientV1Beta1 DeploymentsV1Beta1(this IKubeApiClient kubeClient)
+        public static IDeploymentClientV1Beta1 DeploymentsV1Beta1(this IKubeApiClient kubeClient)
         {
             if (kubeClient == null)
                 throw new ArgumentNullException(nameof(kubeClient));
@@ -113,7 +113,7 @@ namespace KubeClient
         /// <returns>
         ///     The resource client.
         /// </returns>
-        public static PersistentVolumeClientV1 PersistentVolumesV1(this IKubeApiClient kubeClient)
+        public static IPersistentVolumeClientV1 PersistentVolumesV1(this IKubeApiClient kubeClient)
         {
             if (kubeClient == null)
                 throw new ArgumentNullException(nameof(kubeClient));
@@ -132,7 +132,7 @@ namespace KubeClient
         /// <returns>
         ///     The resource client.
         /// </returns>
-        public static PersistentVolumeClaimClientV1 PersistentVolumeClaimsV1(this IKubeApiClient kubeClient)
+        public static IPersistentVolumeClaimClientV1 PersistentVolumeClaimsV1(this IKubeApiClient kubeClient)
         {
             if (kubeClient == null)
                 throw new ArgumentNullException(nameof(kubeClient));

--- a/src/KubeClient/ResourceClients/DeploymentClientV1.cs
+++ b/src/KubeClient/ResourceClients/DeploymentClientV1.cs
@@ -13,7 +13,7 @@ namespace KubeClient.ResourceClients
     ///     A client for the Kubernetes Deployments (v1) API.
     /// </summary>
     public class DeploymentClientV1
-        : KubeResourceClient
+        : KubeResourceClient, IDeploymentClientV1
     {
         /// <summary>
         ///     Create a new <see cref="DeploymentClientV1"/>.

--- a/src/KubeClient/ResourceClients/DeploymentClientV1Beta1.cs
+++ b/src/KubeClient/ResourceClients/DeploymentClientV1Beta1.cs
@@ -13,7 +13,7 @@ namespace KubeClient.ResourceClients
     ///     A client for the Kubernetes Deployments (v1beta2) API.
     /// </summary>
     public class DeploymentClientV1Beta1
-        : KubeResourceClient
+        : KubeResourceClient, IDeploymentClientV1Beta1
     {
         /// <summary>
         ///     Create a new <see cref="DeploymentClientV1Beta1"/>.


### PR DESCRIPTION
There are interfaces for `DeploymentClientV1` and `DeploymentClientV1Beta1` but the classes do not actually implement their respective interfaces. This PR corrects that.