### PR TITLE
Use groupversion rather than version when decorating models with [KubeObject] or [KubeListItem] attribute

### DIFF
--- a/src/KubeClient/Models/generated/APIServiceListV1.cs
+++ b/src/KubeClient/Models/generated/APIServiceListV1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     APIServiceList is a list of APIService objects.
     /// </summary>
-    [KubeListItem("APIService", "v1")]
-    [KubeObject("APIServiceList", "v1")]
+    [KubeListItem("APIService", "apiregistration.k8s.io/v1")]
+    [KubeObject("APIServiceList", "apiregistration.k8s.io/v1")]
     public partial class APIServiceListV1 : KubeResourceListV1<APIServiceV1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/APIServiceListV1Beta1.cs
+++ b/src/KubeClient/Models/generated/APIServiceListV1Beta1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     APIServiceList is a list of APIService objects.
     /// </summary>
-    [KubeListItem("APIService", "v1beta1")]
-    [KubeObject("APIServiceList", "v1beta1")]
+    [KubeListItem("APIService", "apiregistration.k8s.io/v1beta1")]
+    [KubeObject("APIServiceList", "apiregistration.k8s.io/v1beta1")]
     public partial class APIServiceListV1Beta1 : KubeResourceListV1<APIServiceV1Beta1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/APIServiceV1.cs
+++ b/src/KubeClient/Models/generated/APIServiceV1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     APIService represents a server for a particular GroupVersion. Name must be "version.group".
     /// </summary>
-    [KubeObject("APIService", "v1")]
+    [KubeObject("APIService", "apiregistration.k8s.io/v1")]
     [KubeApi(KubeAction.List, "apis/apiregistration.k8s.io/v1/apiservices")]
     [KubeApi(KubeAction.Create, "apis/apiregistration.k8s.io/v1/apiservices")]
     [KubeApi(KubeAction.Get, "apis/apiregistration.k8s.io/v1/apiservices/{name}")]

--- a/src/KubeClient/Models/generated/APIServiceV1Beta1.cs
+++ b/src/KubeClient/Models/generated/APIServiceV1Beta1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     APIService represents a server for a particular GroupVersion. Name must be "version.group".
     /// </summary>
-    [KubeObject("APIService", "v1beta1")]
+    [KubeObject("APIService", "apiregistration.k8s.io/v1beta1")]
     [KubeApi(KubeAction.List, "apis/apiregistration.k8s.io/v1beta1/apiservices")]
     [KubeApi(KubeAction.Create, "apis/apiregistration.k8s.io/v1beta1/apiservices")]
     [KubeApi(KubeAction.Get, "apis/apiregistration.k8s.io/v1beta1/apiservices/{name}")]

--- a/src/KubeClient/Models/generated/CertificateSigningRequestListV1Beta1.cs
+++ b/src/KubeClient/Models/generated/CertificateSigningRequestListV1Beta1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     No description provided.
     /// </summary>
-    [KubeListItem("CertificateSigningRequest", "v1beta1")]
-    [KubeObject("CertificateSigningRequestList", "v1beta1")]
+    [KubeListItem("CertificateSigningRequest", "certificates.k8s.io/v1beta1")]
+    [KubeObject("CertificateSigningRequestList", "certificates.k8s.io/v1beta1")]
     public partial class CertificateSigningRequestListV1Beta1 : KubeResourceListV1<CertificateSigningRequestV1Beta1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/CertificateSigningRequestV1Beta1.cs
+++ b/src/KubeClient/Models/generated/CertificateSigningRequestV1Beta1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     Describes a certificate signing request
     /// </summary>
-    [KubeObject("CertificateSigningRequest", "v1beta1")]
+    [KubeObject("CertificateSigningRequest", "certificates.k8s.io/v1beta1")]
     [KubeApi(KubeAction.List, "apis/certificates.k8s.io/v1beta1/certificatesigningrequests")]
     [KubeApi(KubeAction.Create, "apis/certificates.k8s.io/v1beta1/certificatesigningrequests")]
     [KubeApi(KubeAction.Get, "apis/certificates.k8s.io/v1beta1/certificatesigningrequests/{name}")]

--- a/src/KubeClient/Models/generated/ClusterRoleBindingListV1.cs
+++ b/src/KubeClient/Models/generated/ClusterRoleBindingListV1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     ClusterRoleBindingList is a collection of ClusterRoleBindings
     /// </summary>
-    [KubeListItem("ClusterRoleBinding", "v1")]
-    [KubeObject("ClusterRoleBindingList", "v1")]
+    [KubeListItem("ClusterRoleBinding", "rbac.authorization.k8s.io/v1")]
+    [KubeObject("ClusterRoleBindingList", "rbac.authorization.k8s.io/v1")]
     public partial class ClusterRoleBindingListV1 : KubeResourceListV1<ClusterRoleBindingV1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/ClusterRoleBindingListV1Alpha1.cs
+++ b/src/KubeClient/Models/generated/ClusterRoleBindingListV1Alpha1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     ClusterRoleBindingList is a collection of ClusterRoleBindings
     /// </summary>
-    [KubeListItem("ClusterRoleBinding", "v1alpha1")]
-    [KubeObject("ClusterRoleBindingList", "v1alpha1")]
+    [KubeListItem("ClusterRoleBinding", "rbac.authorization.k8s.io/v1alpha1")]
+    [KubeObject("ClusterRoleBindingList", "rbac.authorization.k8s.io/v1alpha1")]
     public partial class ClusterRoleBindingListV1Alpha1 : KubeResourceListV1<ClusterRoleBindingV1Alpha1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/ClusterRoleBindingListV1Beta1.cs
+++ b/src/KubeClient/Models/generated/ClusterRoleBindingListV1Beta1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     ClusterRoleBindingList is a collection of ClusterRoleBindings
     /// </summary>
-    [KubeListItem("ClusterRoleBinding", "v1beta1")]
-    [KubeObject("ClusterRoleBindingList", "v1beta1")]
+    [KubeListItem("ClusterRoleBinding", "rbac.authorization.k8s.io/v1beta1")]
+    [KubeObject("ClusterRoleBindingList", "rbac.authorization.k8s.io/v1beta1")]
     public partial class ClusterRoleBindingListV1Beta1 : KubeResourceListV1<ClusterRoleBindingV1Beta1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/ClusterRoleBindingV1.cs
+++ b/src/KubeClient/Models/generated/ClusterRoleBindingV1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.
     /// </summary>
-    [KubeObject("ClusterRoleBinding", "v1")]
+    [KubeObject("ClusterRoleBinding", "rbac.authorization.k8s.io/v1")]
     [KubeApi(KubeAction.List, "apis/rbac.authorization.k8s.io/v1/clusterrolebindings")]
     [KubeApi(KubeAction.Create, "apis/rbac.authorization.k8s.io/v1/clusterrolebindings")]
     [KubeApi(KubeAction.Get, "apis/rbac.authorization.k8s.io/v1/clusterrolebindings/{name}")]

--- a/src/KubeClient/Models/generated/ClusterRoleBindingV1Alpha1.cs
+++ b/src/KubeClient/Models/generated/ClusterRoleBindingV1Alpha1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.
     /// </summary>
-    [KubeObject("ClusterRoleBinding", "v1alpha1")]
+    [KubeObject("ClusterRoleBinding", "rbac.authorization.k8s.io/v1alpha1")]
     [KubeApi(KubeAction.List, "apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindings")]
     [KubeApi(KubeAction.Create, "apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindings")]
     [KubeApi(KubeAction.Get, "apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindings/{name}")]

--- a/src/KubeClient/Models/generated/ClusterRoleBindingV1Beta1.cs
+++ b/src/KubeClient/Models/generated/ClusterRoleBindingV1Beta1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.
     /// </summary>
-    [KubeObject("ClusterRoleBinding", "v1beta1")]
+    [KubeObject("ClusterRoleBinding", "rbac.authorization.k8s.io/v1beta1")]
     [KubeApi(KubeAction.List, "apis/rbac.authorization.k8s.io/v1beta1/clusterrolebindings")]
     [KubeApi(KubeAction.Create, "apis/rbac.authorization.k8s.io/v1beta1/clusterrolebindings")]
     [KubeApi(KubeAction.Get, "apis/rbac.authorization.k8s.io/v1beta1/clusterrolebindings/{name}")]

--- a/src/KubeClient/Models/generated/ClusterRoleListV1.cs
+++ b/src/KubeClient/Models/generated/ClusterRoleListV1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     ClusterRoleList is a collection of ClusterRoles
     /// </summary>
-    [KubeListItem("ClusterRole", "v1")]
-    [KubeObject("ClusterRoleList", "v1")]
+    [KubeListItem("ClusterRole", "rbac.authorization.k8s.io/v1")]
+    [KubeObject("ClusterRoleList", "rbac.authorization.k8s.io/v1")]
     public partial class ClusterRoleListV1 : KubeResourceListV1<ClusterRoleV1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/ClusterRoleListV1Alpha1.cs
+++ b/src/KubeClient/Models/generated/ClusterRoleListV1Alpha1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     ClusterRoleList is a collection of ClusterRoles
     /// </summary>
-    [KubeListItem("ClusterRole", "v1alpha1")]
-    [KubeObject("ClusterRoleList", "v1alpha1")]
+    [KubeListItem("ClusterRole", "rbac.authorization.k8s.io/v1alpha1")]
+    [KubeObject("ClusterRoleList", "rbac.authorization.k8s.io/v1alpha1")]
     public partial class ClusterRoleListV1Alpha1 : KubeResourceListV1<ClusterRoleV1Alpha1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/ClusterRoleListV1Beta1.cs
+++ b/src/KubeClient/Models/generated/ClusterRoleListV1Beta1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     ClusterRoleList is a collection of ClusterRoles
     /// </summary>
-    [KubeListItem("ClusterRole", "v1beta1")]
-    [KubeObject("ClusterRoleList", "v1beta1")]
+    [KubeListItem("ClusterRole", "rbac.authorization.k8s.io/v1beta1")]
+    [KubeObject("ClusterRoleList", "rbac.authorization.k8s.io/v1beta1")]
     public partial class ClusterRoleListV1Beta1 : KubeResourceListV1<ClusterRoleV1Beta1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/ClusterRoleV1.cs
+++ b/src/KubeClient/Models/generated/ClusterRoleV1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
     /// </summary>
-    [KubeObject("ClusterRole", "v1")]
+    [KubeObject("ClusterRole", "rbac.authorization.k8s.io/v1")]
     [KubeApi(KubeAction.List, "apis/rbac.authorization.k8s.io/v1/clusterroles")]
     [KubeApi(KubeAction.Create, "apis/rbac.authorization.k8s.io/v1/clusterroles")]
     [KubeApi(KubeAction.Get, "apis/rbac.authorization.k8s.io/v1/clusterroles/{name}")]

--- a/src/KubeClient/Models/generated/ClusterRoleV1Alpha1.cs
+++ b/src/KubeClient/Models/generated/ClusterRoleV1Alpha1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
     /// </summary>
-    [KubeObject("ClusterRole", "v1alpha1")]
+    [KubeObject("ClusterRole", "rbac.authorization.k8s.io/v1alpha1")]
     [KubeApi(KubeAction.List, "apis/rbac.authorization.k8s.io/v1alpha1/clusterroles")]
     [KubeApi(KubeAction.Create, "apis/rbac.authorization.k8s.io/v1alpha1/clusterroles")]
     [KubeApi(KubeAction.Get, "apis/rbac.authorization.k8s.io/v1alpha1/clusterroles/{name}")]

--- a/src/KubeClient/Models/generated/ClusterRoleV1Beta1.cs
+++ b/src/KubeClient/Models/generated/ClusterRoleV1Beta1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
     /// </summary>
-    [KubeObject("ClusterRole", "v1beta1")]
+    [KubeObject("ClusterRole", "rbac.authorization.k8s.io/v1beta1")]
     [KubeApi(KubeAction.List, "apis/rbac.authorization.k8s.io/v1beta1/clusterroles")]
     [KubeApi(KubeAction.Create, "apis/rbac.authorization.k8s.io/v1beta1/clusterroles")]
     [KubeApi(KubeAction.Get, "apis/rbac.authorization.k8s.io/v1beta1/clusterroles/{name}")]

--- a/src/KubeClient/Models/generated/ControllerRevisionListV1.cs
+++ b/src/KubeClient/Models/generated/ControllerRevisionListV1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     ControllerRevisionList is a resource containing a list of ControllerRevision objects.
     /// </summary>
-    [KubeListItem("ControllerRevision", "v1")]
-    [KubeObject("ControllerRevisionList", "v1")]
+    [KubeListItem("ControllerRevision", "apps/v1")]
+    [KubeObject("ControllerRevisionList", "apps/v1")]
     public partial class ControllerRevisionListV1 : KubeResourceListV1<ControllerRevisionV1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/ControllerRevisionV1.cs
+++ b/src/KubeClient/Models/generated/ControllerRevisionV1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
     /// </summary>
-    [KubeObject("ControllerRevision", "v1")]
+    [KubeObject("ControllerRevision", "apps/v1")]
     [KubeApi(KubeAction.List, "apis/apps/v1/controllerrevisions")]
     [KubeApi(KubeAction.WatchList, "apis/apps/v1/watch/controllerrevisions")]
     [KubeApi(KubeAction.List, "apis/apps/v1/namespaces/{namespace}/controllerrevisions")]

--- a/src/KubeClient/Models/generated/CronJobListV1Beta1.cs
+++ b/src/KubeClient/Models/generated/CronJobListV1Beta1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     CronJobList is a collection of cron jobs.
     /// </summary>
-    [KubeListItem("CronJob", "v1beta1")]
-    [KubeObject("CronJobList", "v1beta1")]
+    [KubeListItem("CronJob", "batch/v1beta1")]
+    [KubeObject("CronJobList", "batch/v1beta1")]
     public partial class CronJobListV1Beta1 : KubeResourceListV1<CronJobV1Beta1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/CronJobListV2Alpha1.cs
+++ b/src/KubeClient/Models/generated/CronJobListV2Alpha1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     CronJobList is a collection of cron jobs.
     /// </summary>
-    [KubeListItem("CronJob", "v2alpha1")]
-    [KubeObject("CronJobList", "v2alpha1")]
+    [KubeListItem("CronJob", "batch/v2alpha1")]
+    [KubeObject("CronJobList", "batch/v2alpha1")]
     public partial class CronJobListV2Alpha1 : KubeResourceListV1<CronJobV2Alpha1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/CronJobV1Beta1.cs
+++ b/src/KubeClient/Models/generated/CronJobV1Beta1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     CronJob represents the configuration of a single cron job.
     /// </summary>
-    [KubeObject("CronJob", "v1beta1")]
+    [KubeObject("CronJob", "batch/v1beta1")]
     [KubeApi(KubeAction.List, "apis/batch/v1beta1/cronjobs")]
     [KubeApi(KubeAction.WatchList, "apis/batch/v1beta1/watch/cronjobs")]
     [KubeApi(KubeAction.List, "apis/batch/v1beta1/namespaces/{namespace}/cronjobs")]

--- a/src/KubeClient/Models/generated/CronJobV2Alpha1.cs
+++ b/src/KubeClient/Models/generated/CronJobV2Alpha1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     CronJob represents the configuration of a single cron job.
     /// </summary>
-    [KubeObject("CronJob", "v2alpha1")]
+    [KubeObject("CronJob", "batch/v2alpha1")]
     [KubeApi(KubeAction.List, "apis/batch/v2alpha1/cronjobs")]
     [KubeApi(KubeAction.WatchList, "apis/batch/v2alpha1/watch/cronjobs")]
     [KubeApi(KubeAction.List, "apis/batch/v2alpha1/namespaces/{namespace}/cronjobs")]

--- a/src/KubeClient/Models/generated/CustomResourceDefinitionListV1Beta1.cs
+++ b/src/KubeClient/Models/generated/CustomResourceDefinitionListV1Beta1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     CustomResourceDefinitionList is a list of CustomResourceDefinition objects.
     /// </summary>
-    [KubeListItem("CustomResourceDefinition", "v1beta1")]
-    [KubeObject("CustomResourceDefinitionList", "v1beta1")]
+    [KubeListItem("CustomResourceDefinition", "apiextensions.k8s.io/v1beta1")]
+    [KubeObject("CustomResourceDefinitionList", "apiextensions.k8s.io/v1beta1")]
     public partial class CustomResourceDefinitionListV1Beta1 : KubeResourceListV1<CustomResourceDefinitionV1Beta1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/CustomResourceDefinitionV1Beta1.cs
+++ b/src/KubeClient/Models/generated/CustomResourceDefinitionV1Beta1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format &lt;.spec.name&gt;.&lt;.spec.group&gt;.
     /// </summary>
-    [KubeObject("CustomResourceDefinition", "v1beta1")]
+    [KubeObject("CustomResourceDefinition", "apiextensions.k8s.io/v1beta1")]
     [KubeApi(KubeAction.List, "apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions")]
     [KubeApi(KubeAction.Create, "apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions")]
     [KubeApi(KubeAction.Get, "apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/{name}")]

--- a/src/KubeClient/Models/generated/DaemonSetListV1.cs
+++ b/src/KubeClient/Models/generated/DaemonSetListV1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     DaemonSetList is a collection of daemon sets.
     /// </summary>
-    [KubeListItem("DaemonSet", "v1")]
-    [KubeObject("DaemonSetList", "v1")]
+    [KubeListItem("DaemonSet", "apps/v1")]
+    [KubeObject("DaemonSetList", "apps/v1")]
     public partial class DaemonSetListV1 : KubeResourceListV1<DaemonSetV1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/DaemonSetListV1Beta2.cs
+++ b/src/KubeClient/Models/generated/DaemonSetListV1Beta2.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     DaemonSetList is a collection of daemon sets.
     /// </summary>
-    [KubeListItem("DaemonSet", "v1beta2")]
-    [KubeObject("DaemonSetList", "v1beta2")]
+    [KubeListItem("DaemonSet", "apps/v1beta2")]
+    [KubeObject("DaemonSetList", "apps/v1beta2")]
     public partial class DaemonSetListV1Beta2 : KubeResourceListV1<DaemonSetV1Beta2>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/DaemonSetV1.cs
+++ b/src/KubeClient/Models/generated/DaemonSetV1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     DaemonSet represents the configuration of a daemon set.
     /// </summary>
-    [KubeObject("DaemonSet", "v1")]
+    [KubeObject("DaemonSet", "apps/v1")]
     [KubeApi(KubeAction.List, "apis/apps/v1/daemonsets")]
     [KubeApi(KubeAction.WatchList, "apis/apps/v1/watch/daemonsets")]
     [KubeApi(KubeAction.List, "apis/apps/v1/namespaces/{namespace}/daemonsets")]

--- a/src/KubeClient/Models/generated/DaemonSetV1Beta2.cs
+++ b/src/KubeClient/Models/generated/DaemonSetV1Beta2.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     DEPRECATED - This group version of DaemonSet is deprecated by apps/v1/DaemonSet. See the release notes for more information. DaemonSet represents the configuration of a daemon set.
     /// </summary>
-    [KubeObject("DaemonSet", "v1beta2")]
+    [KubeObject("DaemonSet", "apps/v1beta2")]
     [KubeApi(KubeAction.List, "apis/apps/v1beta2/daemonsets")]
     [KubeApi(KubeAction.WatchList, "apis/apps/v1beta2/watch/daemonsets")]
     [KubeApi(KubeAction.List, "apis/apps/v1beta2/namespaces/{namespace}/daemonsets")]

--- a/src/KubeClient/Models/generated/DeploymentListV1.cs
+++ b/src/KubeClient/Models/generated/DeploymentListV1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     DeploymentList is a list of Deployments.
     /// </summary>
-    [KubeListItem("Deployment", "v1")]
-    [KubeObject("DeploymentList", "v1")]
+    [KubeListItem("Deployment", "apps/v1")]
+    [KubeObject("DeploymentList", "apps/v1")]
     public partial class DeploymentListV1 : KubeResourceListV1<DeploymentV1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/DeploymentListV1Beta1.cs
+++ b/src/KubeClient/Models/generated/DeploymentListV1Beta1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     DeploymentList is a list of Deployments.
     /// </summary>
-    [KubeListItem("Deployment", "v1beta1")]
-    [KubeObject("DeploymentList", "v1beta1")]
+    [KubeListItem("Deployment", "apps/v1beta1")]
+    [KubeObject("DeploymentList", "apps/v1beta1")]
     public partial class DeploymentListV1Beta1 : KubeResourceListV1<DeploymentV1Beta1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/DeploymentListV1Beta2.cs
+++ b/src/KubeClient/Models/generated/DeploymentListV1Beta2.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     DeploymentList is a list of Deployments.
     /// </summary>
-    [KubeListItem("Deployment", "v1beta2")]
-    [KubeObject("DeploymentList", "v1beta2")]
+    [KubeListItem("Deployment", "apps/v1beta2")]
+    [KubeObject("DeploymentList", "apps/v1beta2")]
     public partial class DeploymentListV1Beta2 : KubeResourceListV1<DeploymentV1Beta2>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/DeploymentV1.cs
+++ b/src/KubeClient/Models/generated/DeploymentV1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     Deployment enables declarative updates for Pods and ReplicaSets.
     /// </summary>
-    [KubeObject("Deployment", "v1")]
+    [KubeObject("Deployment", "apps/v1")]
     [KubeApi(KubeAction.List, "apis/apps/v1/deployments")]
     [KubeApi(KubeAction.WatchList, "apis/apps/v1/watch/deployments")]
     [KubeApi(KubeAction.List, "apis/apps/v1/namespaces/{namespace}/deployments")]

--- a/src/KubeClient/Models/generated/DeploymentV1Beta1.cs
+++ b/src/KubeClient/Models/generated/DeploymentV1Beta1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for more information. Deployment enables declarative updates for Pods and ReplicaSets.
     /// </summary>
-    [KubeObject("Deployment", "v1beta1")]
+    [KubeObject("Deployment", "apps/v1beta1")]
     [KubeApi(KubeAction.List, "apis/apps/v1beta1/deployments")]
     [KubeApi(KubeAction.WatchList, "apis/apps/v1beta1/watch/deployments")]
     [KubeApi(KubeAction.List, "apis/apps/v1beta1/namespaces/{namespace}/deployments")]

--- a/src/KubeClient/Models/generated/DeploymentV1Beta2.cs
+++ b/src/KubeClient/Models/generated/DeploymentV1Beta2.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     DEPRECATED - This group version of Deployment is deprecated by apps/v1/Deployment. See the release notes for more information. Deployment enables declarative updates for Pods and ReplicaSets.
     /// </summary>
-    [KubeObject("Deployment", "v1beta2")]
+    [KubeObject("Deployment", "apps/v1beta2")]
     [KubeApi(KubeAction.List, "apis/apps/v1beta2/deployments")]
     [KubeApi(KubeAction.WatchList, "apis/apps/v1beta2/watch/deployments")]
     [KubeApi(KubeAction.List, "apis/apps/v1beta2/namespaces/{namespace}/deployments")]

--- a/src/KubeClient/Models/generated/EventListV1Beta1.cs
+++ b/src/KubeClient/Models/generated/EventListV1Beta1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     EventList is a list of Event objects.
     /// </summary>
-    [KubeListItem("Event", "v1beta1")]
-    [KubeObject("EventList", "v1beta1")]
+    [KubeListItem("Event", "events.k8s.io/v1beta1")]
+    [KubeObject("EventList", "events.k8s.io/v1beta1")]
     public partial class EventListV1Beta1 : KubeResourceListV1<EventV1Beta1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/EventV1Beta1.cs
+++ b/src/KubeClient/Models/generated/EventV1Beta1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     Event is a report of an event somewhere in the cluster. It generally denotes some state change in the system.
     /// </summary>
-    [KubeObject("Event", "v1beta1")]
+    [KubeObject("Event", "events.k8s.io/v1beta1")]
     [KubeApi(KubeAction.List, "apis/events.k8s.io/v1beta1/events")]
     [KubeApi(KubeAction.WatchList, "apis/events.k8s.io/v1beta1/watch/events")]
     [KubeApi(KubeAction.List, "apis/events.k8s.io/v1beta1/namespaces/{namespace}/events")]

--- a/src/KubeClient/Models/generated/EvictionV1Beta1.cs
+++ b/src/KubeClient/Models/generated/EvictionV1Beta1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     Eviction evicts a pod from its node subject to certain policies and safety constraints. This is a subresource of Pod.  A request to cause such an eviction is created by POSTing to .../pods/&lt;pod name&gt;/evictions.
     /// </summary>
-    [KubeObject("Eviction", "v1beta1")]
+    [KubeObject("Eviction", "policy/v1beta1")]
     [KubeApi(KubeAction.Create, "api/v1/namespaces/{namespace}/pods/{name}/eviction")]
     public partial class EvictionV1Beta1 : KubeResourceV1
     {

--- a/src/KubeClient/Models/generated/HorizontalPodAutoscalerListV1.cs
+++ b/src/KubeClient/Models/generated/HorizontalPodAutoscalerListV1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     list of horizontal pod autoscaler objects.
     /// </summary>
-    [KubeListItem("HorizontalPodAutoscaler", "v1")]
-    [KubeObject("HorizontalPodAutoscalerList", "v1")]
+    [KubeListItem("HorizontalPodAutoscaler", "autoscaling/v1")]
+    [KubeObject("HorizontalPodAutoscalerList", "autoscaling/v1")]
     public partial class HorizontalPodAutoscalerListV1 : KubeResourceListV1<HorizontalPodAutoscalerV1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/HorizontalPodAutoscalerListV2Beta1.cs
+++ b/src/KubeClient/Models/generated/HorizontalPodAutoscalerListV2Beta1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     HorizontalPodAutoscaler is a list of horizontal pod autoscaler objects.
     /// </summary>
-    [KubeListItem("HorizontalPodAutoscaler", "v2beta1")]
-    [KubeObject("HorizontalPodAutoscalerList", "v2beta1")]
+    [KubeListItem("HorizontalPodAutoscaler", "autoscaling/v2beta1")]
+    [KubeObject("HorizontalPodAutoscalerList", "autoscaling/v2beta1")]
     public partial class HorizontalPodAutoscalerListV2Beta1 : KubeResourceListV1<HorizontalPodAutoscalerV2Beta1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/HorizontalPodAutoscalerV1.cs
+++ b/src/KubeClient/Models/generated/HorizontalPodAutoscalerV1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     configuration of a horizontal pod autoscaler.
     /// </summary>
-    [KubeObject("HorizontalPodAutoscaler", "v1")]
+    [KubeObject("HorizontalPodAutoscaler", "autoscaling/v1")]
     [KubeApi(KubeAction.List, "apis/autoscaling/v1/horizontalpodautoscalers")]
     [KubeApi(KubeAction.WatchList, "apis/autoscaling/v1/watch/horizontalpodautoscalers")]
     [KubeApi(KubeAction.List, "apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers")]

--- a/src/KubeClient/Models/generated/HorizontalPodAutoscalerV2Beta1.cs
+++ b/src/KubeClient/Models/generated/HorizontalPodAutoscalerV2Beta1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
     /// </summary>
-    [KubeObject("HorizontalPodAutoscaler", "v2beta1")]
+    [KubeObject("HorizontalPodAutoscaler", "autoscaling/v2beta1")]
     [KubeApi(KubeAction.List, "apis/autoscaling/v2beta1/horizontalpodautoscalers")]
     [KubeApi(KubeAction.WatchList, "apis/autoscaling/v2beta1/watch/horizontalpodautoscalers")]
     [KubeApi(KubeAction.List, "apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers")]

--- a/src/KubeClient/Models/generated/InitializerConfigurationListV1Alpha1.cs
+++ b/src/KubeClient/Models/generated/InitializerConfigurationListV1Alpha1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     InitializerConfigurationList is a list of InitializerConfiguration.
     /// </summary>
-    [KubeListItem("InitializerConfiguration", "v1alpha1")]
-    [KubeObject("InitializerConfigurationList", "v1alpha1")]
+    [KubeListItem("InitializerConfiguration", "admissionregistration.k8s.io/v1alpha1")]
+    [KubeObject("InitializerConfigurationList", "admissionregistration.k8s.io/v1alpha1")]
     public partial class InitializerConfigurationListV1Alpha1 : KubeResourceListV1<InitializerConfigurationV1Alpha1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/InitializerConfigurationV1Alpha1.cs
+++ b/src/KubeClient/Models/generated/InitializerConfigurationV1Alpha1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     InitializerConfiguration describes the configuration of initializers.
     /// </summary>
-    [KubeObject("InitializerConfiguration", "v1alpha1")]
+    [KubeObject("InitializerConfiguration", "admissionregistration.k8s.io/v1alpha1")]
     [KubeApi(KubeAction.List, "apis/admissionregistration.k8s.io/v1alpha1/initializerconfigurations")]
     [KubeApi(KubeAction.Create, "apis/admissionregistration.k8s.io/v1alpha1/initializerconfigurations")]
     [KubeApi(KubeAction.Get, "apis/admissionregistration.k8s.io/v1alpha1/initializerconfigurations/{name}")]

--- a/src/KubeClient/Models/generated/JobListV1.cs
+++ b/src/KubeClient/Models/generated/JobListV1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     JobList is a collection of jobs.
     /// </summary>
-    [KubeListItem("Job", "v1")]
-    [KubeObject("JobList", "v1")]
+    [KubeListItem("Job", "batch/v1")]
+    [KubeObject("JobList", "batch/v1")]
     public partial class JobListV1 : KubeResourceListV1<JobV1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/JobV1.cs
+++ b/src/KubeClient/Models/generated/JobV1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     Job represents the configuration of a single job.
     /// </summary>
-    [KubeObject("Job", "v1")]
+    [KubeObject("Job", "batch/v1")]
     [KubeApi(KubeAction.List, "apis/batch/v1/jobs")]
     [KubeApi(KubeAction.WatchList, "apis/batch/v1/watch/jobs")]
     [KubeApi(KubeAction.List, "apis/batch/v1/namespaces/{namespace}/jobs")]

--- a/src/KubeClient/Models/generated/LocalSubjectAccessReviewV1.cs
+++ b/src/KubeClient/Models/generated/LocalSubjectAccessReviewV1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.
     /// </summary>
-    [KubeObject("LocalSubjectAccessReview", "v1")]
+    [KubeObject("LocalSubjectAccessReview", "authorization.k8s.io/v1")]
     [KubeApi(KubeAction.Create, "apis/authorization.k8s.io/v1/namespaces/{namespace}/localsubjectaccessreviews")]
     public partial class LocalSubjectAccessReviewV1 : KubeResourceV1
     {

--- a/src/KubeClient/Models/generated/LocalSubjectAccessReviewV1Beta1.cs
+++ b/src/KubeClient/Models/generated/LocalSubjectAccessReviewV1Beta1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.
     /// </summary>
-    [KubeObject("LocalSubjectAccessReview", "v1beta1")]
+    [KubeObject("LocalSubjectAccessReview", "authorization.k8s.io/v1beta1")]
     [KubeApi(KubeAction.Create, "apis/authorization.k8s.io/v1beta1/namespaces/{namespace}/localsubjectaccessreviews")]
     public partial class LocalSubjectAccessReviewV1Beta1 : KubeResourceV1
     {

--- a/src/KubeClient/Models/generated/MutatingWebhookConfigurationListV1Beta1.cs
+++ b/src/KubeClient/Models/generated/MutatingWebhookConfigurationListV1Beta1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     MutatingWebhookConfigurationList is a list of MutatingWebhookConfiguration.
     /// </summary>
-    [KubeListItem("MutatingWebhookConfiguration", "v1beta1")]
-    [KubeObject("MutatingWebhookConfigurationList", "v1beta1")]
+    [KubeListItem("MutatingWebhookConfiguration", "admissionregistration.k8s.io/v1beta1")]
+    [KubeObject("MutatingWebhookConfigurationList", "admissionregistration.k8s.io/v1beta1")]
     public partial class MutatingWebhookConfigurationListV1Beta1 : KubeResourceListV1<MutatingWebhookConfigurationV1Beta1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/MutatingWebhookConfigurationV1Beta1.cs
+++ b/src/KubeClient/Models/generated/MutatingWebhookConfigurationV1Beta1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object.
     /// </summary>
-    [KubeObject("MutatingWebhookConfiguration", "v1beta1")]
+    [KubeObject("MutatingWebhookConfiguration", "admissionregistration.k8s.io/v1beta1")]
     [KubeApi(KubeAction.List, "apis/admissionregistration.k8s.io/v1beta1/mutatingwebhookconfigurations")]
     [KubeApi(KubeAction.Create, "apis/admissionregistration.k8s.io/v1beta1/mutatingwebhookconfigurations")]
     [KubeApi(KubeAction.Get, "apis/admissionregistration.k8s.io/v1beta1/mutatingwebhookconfigurations/{name}")]

--- a/src/KubeClient/Models/generated/NetworkPolicyListV1.cs
+++ b/src/KubeClient/Models/generated/NetworkPolicyListV1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     NetworkPolicyList is a list of NetworkPolicy objects.
     /// </summary>
-    [KubeListItem("NetworkPolicy", "v1")]
-    [KubeObject("NetworkPolicyList", "v1")]
+    [KubeListItem("NetworkPolicy", "networking.k8s.io/v1")]
+    [KubeObject("NetworkPolicyList", "networking.k8s.io/v1")]
     public partial class NetworkPolicyListV1 : KubeResourceListV1<NetworkPolicyV1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/NetworkPolicyV1.cs
+++ b/src/KubeClient/Models/generated/NetworkPolicyV1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     NetworkPolicy describes what network traffic is allowed for a set of Pods
     /// </summary>
-    [KubeObject("NetworkPolicy", "v1")]
+    [KubeObject("NetworkPolicy", "networking.k8s.io/v1")]
     [KubeApi(KubeAction.List, "apis/networking.k8s.io/v1/networkpolicies")]
     [KubeApi(KubeAction.WatchList, "apis/networking.k8s.io/v1/watch/networkpolicies")]
     [KubeApi(KubeAction.List, "apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies")]

--- a/src/KubeClient/Models/generated/PodDisruptionBudgetListV1Beta1.cs
+++ b/src/KubeClient/Models/generated/PodDisruptionBudgetListV1Beta1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     PodDisruptionBudgetList is a collection of PodDisruptionBudgets.
     /// </summary>
-    [KubeListItem("PodDisruptionBudget", "v1beta1")]
-    [KubeObject("PodDisruptionBudgetList", "v1beta1")]
+    [KubeListItem("PodDisruptionBudget", "policy/v1beta1")]
+    [KubeObject("PodDisruptionBudgetList", "policy/v1beta1")]
     public partial class PodDisruptionBudgetListV1Beta1 : KubeResourceListV1<PodDisruptionBudgetV1Beta1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/PodDisruptionBudgetV1Beta1.cs
+++ b/src/KubeClient/Models/generated/PodDisruptionBudgetV1Beta1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
     /// </summary>
-    [KubeObject("PodDisruptionBudget", "v1beta1")]
+    [KubeObject("PodDisruptionBudget", "policy/v1beta1")]
     [KubeApi(KubeAction.List, "apis/policy/v1beta1/poddisruptionbudgets")]
     [KubeApi(KubeAction.WatchList, "apis/policy/v1beta1/watch/poddisruptionbudgets")]
     [KubeApi(KubeAction.List, "apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets")]

--- a/src/KubeClient/Models/generated/PodPresetListV1Alpha1.cs
+++ b/src/KubeClient/Models/generated/PodPresetListV1Alpha1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     PodPresetList is a list of PodPreset objects.
     /// </summary>
-    [KubeListItem("PodPreset", "v1alpha1")]
-    [KubeObject("PodPresetList", "v1alpha1")]
+    [KubeListItem("PodPreset", "settings.k8s.io/v1alpha1")]
+    [KubeObject("PodPresetList", "settings.k8s.io/v1alpha1")]
     public partial class PodPresetListV1Alpha1 : KubeResourceListV1<PodPresetV1Alpha1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/PodPresetV1Alpha1.cs
+++ b/src/KubeClient/Models/generated/PodPresetV1Alpha1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     PodPreset is a policy resource that defines additional runtime requirements for a Pod.
     /// </summary>
-    [KubeObject("PodPreset", "v1alpha1")]
+    [KubeObject("PodPreset", "settings.k8s.io/v1alpha1")]
     [KubeApi(KubeAction.List, "apis/settings.k8s.io/v1alpha1/podpresets")]
     [KubeApi(KubeAction.WatchList, "apis/settings.k8s.io/v1alpha1/watch/podpresets")]
     [KubeApi(KubeAction.List, "apis/settings.k8s.io/v1alpha1/namespaces/{namespace}/podpresets")]

--- a/src/KubeClient/Models/generated/PodSecurityPolicyListV1Beta1.cs
+++ b/src/KubeClient/Models/generated/PodSecurityPolicyListV1Beta1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     PodSecurityPolicyList is a list of PodSecurityPolicy objects.
     /// </summary>
-    [KubeListItem("PodSecurityPolicy", "v1beta1")]
-    [KubeObject("PodSecurityPolicyList", "v1beta1")]
+    [KubeListItem("PodSecurityPolicy", "policy/v1beta1")]
+    [KubeObject("PodSecurityPolicyList", "policy/v1beta1")]
     public partial class PodSecurityPolicyListV1Beta1 : KubeResourceListV1<PodSecurityPolicyV1Beta1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/PodSecurityPolicyV1Beta1.cs
+++ b/src/KubeClient/Models/generated/PodSecurityPolicyV1Beta1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.
     /// </summary>
-    [KubeObject("PodSecurityPolicy", "v1beta1")]
+    [KubeObject("PodSecurityPolicy", "policy/v1beta1")]
     [KubeApi(KubeAction.List, "apis/policy/v1beta1/podsecuritypolicies")]
     [KubeApi(KubeAction.Create, "apis/policy/v1beta1/podsecuritypolicies")]
     [KubeApi(KubeAction.Get, "apis/policy/v1beta1/podsecuritypolicies/{name}")]

--- a/src/KubeClient/Models/generated/PriorityClassListV1Alpha1.cs
+++ b/src/KubeClient/Models/generated/PriorityClassListV1Alpha1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     PriorityClassList is a collection of priority classes.
     /// </summary>
-    [KubeListItem("PriorityClass", "v1alpha1")]
-    [KubeObject("PriorityClassList", "v1alpha1")]
+    [KubeListItem("PriorityClass", "scheduling.k8s.io/v1alpha1")]
+    [KubeObject("PriorityClassList", "scheduling.k8s.io/v1alpha1")]
     public partial class PriorityClassListV1Alpha1 : KubeResourceListV1<PriorityClassV1Alpha1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/PriorityClassListV1Beta1.cs
+++ b/src/KubeClient/Models/generated/PriorityClassListV1Beta1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     PriorityClassList is a collection of priority classes.
     /// </summary>
-    [KubeListItem("PriorityClass", "v1beta1")]
-    [KubeObject("PriorityClassList", "v1beta1")]
+    [KubeListItem("PriorityClass", "scheduling.k8s.io/v1beta1")]
+    [KubeObject("PriorityClassList", "scheduling.k8s.io/v1beta1")]
     public partial class PriorityClassListV1Beta1 : KubeResourceListV1<PriorityClassV1Beta1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/PriorityClassV1Alpha1.cs
+++ b/src/KubeClient/Models/generated/PriorityClassV1Alpha1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
     /// </summary>
-    [KubeObject("PriorityClass", "v1alpha1")]
+    [KubeObject("PriorityClass", "scheduling.k8s.io/v1alpha1")]
     [KubeApi(KubeAction.List, "apis/scheduling.k8s.io/v1alpha1/priorityclasses")]
     [KubeApi(KubeAction.Create, "apis/scheduling.k8s.io/v1alpha1/priorityclasses")]
     [KubeApi(KubeAction.Get, "apis/scheduling.k8s.io/v1alpha1/priorityclasses/{name}")]

--- a/src/KubeClient/Models/generated/PriorityClassV1Beta1.cs
+++ b/src/KubeClient/Models/generated/PriorityClassV1Beta1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
     /// </summary>
-    [KubeObject("PriorityClass", "v1beta1")]
+    [KubeObject("PriorityClass", "scheduling.k8s.io/v1beta1")]
     [KubeApi(KubeAction.List, "apis/scheduling.k8s.io/v1beta1/priorityclasses")]
     [KubeApi(KubeAction.Create, "apis/scheduling.k8s.io/v1beta1/priorityclasses")]
     [KubeApi(KubeAction.Get, "apis/scheduling.k8s.io/v1beta1/priorityclasses/{name}")]

--- a/src/KubeClient/Models/generated/ReplicaSetListV1.cs
+++ b/src/KubeClient/Models/generated/ReplicaSetListV1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     ReplicaSetList is a collection of ReplicaSets.
     /// </summary>
-    [KubeListItem("ReplicaSet", "v1")]
-    [KubeObject("ReplicaSetList", "v1")]
+    [KubeListItem("ReplicaSet", "apps/v1")]
+    [KubeObject("ReplicaSetList", "apps/v1")]
     public partial class ReplicaSetListV1 : KubeResourceListV1<ReplicaSetV1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/ReplicaSetListV1Beta2.cs
+++ b/src/KubeClient/Models/generated/ReplicaSetListV1Beta2.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     ReplicaSetList is a collection of ReplicaSets.
     /// </summary>
-    [KubeListItem("ReplicaSet", "v1beta2")]
-    [KubeObject("ReplicaSetList", "v1beta2")]
+    [KubeListItem("ReplicaSet", "apps/v1beta2")]
+    [KubeObject("ReplicaSetList", "apps/v1beta2")]
     public partial class ReplicaSetListV1Beta2 : KubeResourceListV1<ReplicaSetV1Beta2>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/ReplicaSetV1.cs
+++ b/src/KubeClient/Models/generated/ReplicaSetV1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     ReplicaSet ensures that a specified number of pod replicas are running at any given time.
     /// </summary>
-    [KubeObject("ReplicaSet", "v1")]
+    [KubeObject("ReplicaSet", "apps/v1")]
     [KubeApi(KubeAction.List, "apis/apps/v1/replicasets")]
     [KubeApi(KubeAction.WatchList, "apis/apps/v1/watch/replicasets")]
     [KubeApi(KubeAction.List, "apis/apps/v1/namespaces/{namespace}/replicasets")]

--- a/src/KubeClient/Models/generated/ReplicaSetV1Beta2.cs
+++ b/src/KubeClient/Models/generated/ReplicaSetV1Beta2.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1/ReplicaSet. See the release notes for more information. ReplicaSet ensures that a specified number of pod replicas are running at any given time.
     /// </summary>
-    [KubeObject("ReplicaSet", "v1beta2")]
+    [KubeObject("ReplicaSet", "apps/v1beta2")]
     [KubeApi(KubeAction.List, "apis/apps/v1beta2/replicasets")]
     [KubeApi(KubeAction.WatchList, "apis/apps/v1beta2/watch/replicasets")]
     [KubeApi(KubeAction.List, "apis/apps/v1beta2/namespaces/{namespace}/replicasets")]

--- a/src/KubeClient/Models/generated/RoleBindingListV1.cs
+++ b/src/KubeClient/Models/generated/RoleBindingListV1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     RoleBindingList is a collection of RoleBindings
     /// </summary>
-    [KubeListItem("RoleBinding", "v1")]
-    [KubeObject("RoleBindingList", "v1")]
+    [KubeListItem("RoleBinding", "rbac.authorization.k8s.io/v1")]
+    [KubeObject("RoleBindingList", "rbac.authorization.k8s.io/v1")]
     public partial class RoleBindingListV1 : KubeResourceListV1<RoleBindingV1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/RoleBindingListV1Alpha1.cs
+++ b/src/KubeClient/Models/generated/RoleBindingListV1Alpha1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     RoleBindingList is a collection of RoleBindings
     /// </summary>
-    [KubeListItem("RoleBinding", "v1alpha1")]
-    [KubeObject("RoleBindingList", "v1alpha1")]
+    [KubeListItem("RoleBinding", "rbac.authorization.k8s.io/v1alpha1")]
+    [KubeObject("RoleBindingList", "rbac.authorization.k8s.io/v1alpha1")]
     public partial class RoleBindingListV1Alpha1 : KubeResourceListV1<RoleBindingV1Alpha1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/RoleBindingListV1Beta1.cs
+++ b/src/KubeClient/Models/generated/RoleBindingListV1Beta1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     RoleBindingList is a collection of RoleBindings
     /// </summary>
-    [KubeListItem("RoleBinding", "v1beta1")]
-    [KubeObject("RoleBindingList", "v1beta1")]
+    [KubeListItem("RoleBinding", "rbac.authorization.k8s.io/v1beta1")]
+    [KubeObject("RoleBindingList", "rbac.authorization.k8s.io/v1beta1")]
     public partial class RoleBindingListV1Beta1 : KubeResourceListV1<RoleBindingV1Beta1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/RoleBindingV1.cs
+++ b/src/KubeClient/Models/generated/RoleBindingV1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.
     /// </summary>
-    [KubeObject("RoleBinding", "v1")]
+    [KubeObject("RoleBinding", "rbac.authorization.k8s.io/v1")]
     [KubeApi(KubeAction.List, "apis/rbac.authorization.k8s.io/v1/rolebindings")]
     [KubeApi(KubeAction.WatchList, "apis/rbac.authorization.k8s.io/v1/watch/rolebindings")]
     [KubeApi(KubeAction.List, "apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings")]

--- a/src/KubeClient/Models/generated/RoleBindingV1Alpha1.cs
+++ b/src/KubeClient/Models/generated/RoleBindingV1Alpha1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.
     /// </summary>
-    [KubeObject("RoleBinding", "v1alpha1")]
+    [KubeObject("RoleBinding", "rbac.authorization.k8s.io/v1alpha1")]
     [KubeApi(KubeAction.List, "apis/rbac.authorization.k8s.io/v1alpha1/rolebindings")]
     [KubeApi(KubeAction.WatchList, "apis/rbac.authorization.k8s.io/v1alpha1/watch/rolebindings")]
     [KubeApi(KubeAction.List, "apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/rolebindings")]

--- a/src/KubeClient/Models/generated/RoleBindingV1Beta1.cs
+++ b/src/KubeClient/Models/generated/RoleBindingV1Beta1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.
     /// </summary>
-    [KubeObject("RoleBinding", "v1beta1")]
+    [KubeObject("RoleBinding", "rbac.authorization.k8s.io/v1beta1")]
     [KubeApi(KubeAction.List, "apis/rbac.authorization.k8s.io/v1beta1/rolebindings")]
     [KubeApi(KubeAction.WatchList, "apis/rbac.authorization.k8s.io/v1beta1/watch/rolebindings")]
     [KubeApi(KubeAction.List, "apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/rolebindings")]

--- a/src/KubeClient/Models/generated/RoleListV1.cs
+++ b/src/KubeClient/Models/generated/RoleListV1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     RoleList is a collection of Roles
     /// </summary>
-    [KubeListItem("Role", "v1")]
-    [KubeObject("RoleList", "v1")]
+    [KubeListItem("Role", "rbac.authorization.k8s.io/v1")]
+    [KubeObject("RoleList", "rbac.authorization.k8s.io/v1")]
     public partial class RoleListV1 : KubeResourceListV1<RoleV1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/RoleListV1Alpha1.cs
+++ b/src/KubeClient/Models/generated/RoleListV1Alpha1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     RoleList is a collection of Roles
     /// </summary>
-    [KubeListItem("Role", "v1alpha1")]
-    [KubeObject("RoleList", "v1alpha1")]
+    [KubeListItem("Role", "rbac.authorization.k8s.io/v1alpha1")]
+    [KubeObject("RoleList", "rbac.authorization.k8s.io/v1alpha1")]
     public partial class RoleListV1Alpha1 : KubeResourceListV1<RoleV1Alpha1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/RoleListV1Beta1.cs
+++ b/src/KubeClient/Models/generated/RoleListV1Beta1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     RoleList is a collection of Roles
     /// </summary>
-    [KubeListItem("Role", "v1beta1")]
-    [KubeObject("RoleList", "v1beta1")]
+    [KubeListItem("Role", "rbac.authorization.k8s.io/v1beta1")]
+    [KubeObject("RoleList", "rbac.authorization.k8s.io/v1beta1")]
     public partial class RoleListV1Beta1 : KubeResourceListV1<RoleV1Beta1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/RoleV1.cs
+++ b/src/KubeClient/Models/generated/RoleV1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
     /// </summary>
-    [KubeObject("Role", "v1")]
+    [KubeObject("Role", "rbac.authorization.k8s.io/v1")]
     [KubeApi(KubeAction.List, "apis/rbac.authorization.k8s.io/v1/roles")]
     [KubeApi(KubeAction.WatchList, "apis/rbac.authorization.k8s.io/v1/watch/roles")]
     [KubeApi(KubeAction.List, "apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles")]

--- a/src/KubeClient/Models/generated/RoleV1Alpha1.cs
+++ b/src/KubeClient/Models/generated/RoleV1Alpha1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
     /// </summary>
-    [KubeObject("Role", "v1alpha1")]
+    [KubeObject("Role", "rbac.authorization.k8s.io/v1alpha1")]
     [KubeApi(KubeAction.List, "apis/rbac.authorization.k8s.io/v1alpha1/roles")]
     [KubeApi(KubeAction.WatchList, "apis/rbac.authorization.k8s.io/v1alpha1/watch/roles")]
     [KubeApi(KubeAction.List, "apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/roles")]

--- a/src/KubeClient/Models/generated/RoleV1Beta1.cs
+++ b/src/KubeClient/Models/generated/RoleV1Beta1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
     /// </summary>
-    [KubeObject("Role", "v1beta1")]
+    [KubeObject("Role", "rbac.authorization.k8s.io/v1beta1")]
     [KubeApi(KubeAction.List, "apis/rbac.authorization.k8s.io/v1beta1/roles")]
     [KubeApi(KubeAction.WatchList, "apis/rbac.authorization.k8s.io/v1beta1/watch/roles")]
     [KubeApi(KubeAction.List, "apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/roles")]

--- a/src/KubeClient/Models/generated/ScaleV1.cs
+++ b/src/KubeClient/Models/generated/ScaleV1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     Scale represents a scaling request for a resource.
     /// </summary>
-    [KubeObject("Scale", "v1")]
+    [KubeObject("Scale", "autoscaling/v1")]
     [KubeApi(KubeAction.Get, "apis/apps/v1/namespaces/{namespace}/deployments/{name}/scale")]
     [KubeApi(KubeAction.Get, "apis/apps/v1/namespaces/{namespace}/replicasets/{name}/scale")]
     [KubeApi(KubeAction.Get, "apis/apps/v1/namespaces/{namespace}/statefulsets/{name}/scale")]

--- a/src/KubeClient/Models/generated/ScaleV1Beta1.cs
+++ b/src/KubeClient/Models/generated/ScaleV1Beta1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     Scale represents a scaling request for a resource.
     /// </summary>
-    [KubeObject("Scale", "v1beta1")]
+    [KubeObject("Scale", "apps/v1beta1")]
     [KubeApi(KubeAction.Get, "apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}/scale")]
     [KubeApi(KubeAction.Get, "apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}/scale")]
     [KubeApi(KubeAction.Patch, "apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}/scale")]

--- a/src/KubeClient/Models/generated/ScaleV1Beta2.cs
+++ b/src/KubeClient/Models/generated/ScaleV1Beta2.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     Scale represents a scaling request for a resource.
     /// </summary>
-    [KubeObject("Scale", "v1beta2")]
+    [KubeObject("Scale", "apps/v1beta2")]
     [KubeApi(KubeAction.Get, "apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}/scale")]
     [KubeApi(KubeAction.Get, "apis/apps/v1beta2/namespaces/{namespace}/replicasets/{name}/scale")]
     [KubeApi(KubeAction.Get, "apis/apps/v1beta2/namespaces/{namespace}/statefulsets/{name}/scale")]

--- a/src/KubeClient/Models/generated/SelfSubjectAccessReviewV1.cs
+++ b/src/KubeClient/Models/generated/SelfSubjectAccessReviewV1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means "in all namespaces".  Self is a special case, because users should always be able to check whether they can perform an action
     /// </summary>
-    [KubeObject("SelfSubjectAccessReview", "v1")]
+    [KubeObject("SelfSubjectAccessReview", "authorization.k8s.io/v1")]
     [KubeApi(KubeAction.Create, "apis/authorization.k8s.io/v1/selfsubjectaccessreviews")]
     public partial class SelfSubjectAccessReviewV1 : KubeResourceV1
     {

--- a/src/KubeClient/Models/generated/SelfSubjectAccessReviewV1Beta1.cs
+++ b/src/KubeClient/Models/generated/SelfSubjectAccessReviewV1Beta1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means "in all namespaces".  Self is a special case, because users should always be able to check whether they can perform an action
     /// </summary>
-    [KubeObject("SelfSubjectAccessReview", "v1beta1")]
+    [KubeObject("SelfSubjectAccessReview", "authorization.k8s.io/v1beta1")]
     [KubeApi(KubeAction.Create, "apis/authorization.k8s.io/v1beta1/selfsubjectaccessreviews")]
     public partial class SelfSubjectAccessReviewV1Beta1 : KubeResourceV1
     {

--- a/src/KubeClient/Models/generated/SelfSubjectRulesReviewV1.cs
+++ b/src/KubeClient/Models/generated/SelfSubjectRulesReviewV1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server's authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.
     /// </summary>
-    [KubeObject("SelfSubjectRulesReview", "v1")]
+    [KubeObject("SelfSubjectRulesReview", "authorization.k8s.io/v1")]
     [KubeApi(KubeAction.Create, "apis/authorization.k8s.io/v1/selfsubjectrulesreviews")]
     public partial class SelfSubjectRulesReviewV1 : KubeResourceV1
     {

--- a/src/KubeClient/Models/generated/SelfSubjectRulesReviewV1Beta1.cs
+++ b/src/KubeClient/Models/generated/SelfSubjectRulesReviewV1Beta1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server's authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.
     /// </summary>
-    [KubeObject("SelfSubjectRulesReview", "v1beta1")]
+    [KubeObject("SelfSubjectRulesReview", "authorization.k8s.io/v1beta1")]
     [KubeApi(KubeAction.Create, "apis/authorization.k8s.io/v1beta1/selfsubjectrulesreviews")]
     public partial class SelfSubjectRulesReviewV1Beta1 : KubeResourceV1
     {

--- a/src/KubeClient/Models/generated/StatefulSetListV1.cs
+++ b/src/KubeClient/Models/generated/StatefulSetListV1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     StatefulSetList is a collection of StatefulSets.
     /// </summary>
-    [KubeListItem("StatefulSet", "v1")]
-    [KubeObject("StatefulSetList", "v1")]
+    [KubeListItem("StatefulSet", "apps/v1")]
+    [KubeObject("StatefulSetList", "apps/v1")]
     public partial class StatefulSetListV1 : KubeResourceListV1<StatefulSetV1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/StatefulSetListV1Beta1.cs
+++ b/src/KubeClient/Models/generated/StatefulSetListV1Beta1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     StatefulSetList is a collection of StatefulSets.
     /// </summary>
-    [KubeListItem("StatefulSet", "v1beta1")]
-    [KubeObject("StatefulSetList", "v1beta1")]
+    [KubeListItem("StatefulSet", "apps/v1beta1")]
+    [KubeObject("StatefulSetList", "apps/v1beta1")]
     public partial class StatefulSetListV1Beta1 : KubeResourceListV1<StatefulSetV1Beta1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/StatefulSetListV1Beta2.cs
+++ b/src/KubeClient/Models/generated/StatefulSetListV1Beta2.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     StatefulSetList is a collection of StatefulSets.
     /// </summary>
-    [KubeListItem("StatefulSet", "v1beta2")]
-    [KubeObject("StatefulSetList", "v1beta2")]
+    [KubeListItem("StatefulSet", "apps/v1beta2")]
+    [KubeObject("StatefulSetList", "apps/v1beta2")]
     public partial class StatefulSetListV1Beta2 : KubeResourceListV1<StatefulSetV1Beta2>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/StatefulSetV1.cs
+++ b/src/KubeClient/Models/generated/StatefulSetV1.cs
@@ -11,7 +11,7 @@ namespace KubeClient.Models
     ///      - Storage: As many VolumeClaims as requested.
     ///     The StatefulSet guarantees that a given network identity will always map to the same storage identity.
     /// </summary>
-    [KubeObject("StatefulSet", "v1")]
+    [KubeObject("StatefulSet", "apps/v1")]
     [KubeApi(KubeAction.List, "apis/apps/v1/statefulsets")]
     [KubeApi(KubeAction.WatchList, "apis/apps/v1/watch/statefulsets")]
     [KubeApi(KubeAction.List, "apis/apps/v1/namespaces/{namespace}/statefulsets")]

--- a/src/KubeClient/Models/generated/StatefulSetV1Beta1.cs
+++ b/src/KubeClient/Models/generated/StatefulSetV1Beta1.cs
@@ -11,7 +11,7 @@ namespace KubeClient.Models
     ///      - Storage: As many VolumeClaims as requested.
     ///     The StatefulSet guarantees that a given network identity will always map to the same storage identity.
     /// </summary>
-    [KubeObject("StatefulSet", "v1beta1")]
+    [KubeObject("StatefulSet", "apps/v1beta1")]
     [KubeApi(KubeAction.List, "apis/apps/v1beta1/statefulsets")]
     [KubeApi(KubeAction.WatchList, "apis/apps/v1beta1/watch/statefulsets")]
     [KubeApi(KubeAction.List, "apis/apps/v1beta1/namespaces/{namespace}/statefulsets")]

--- a/src/KubeClient/Models/generated/StatefulSetV1Beta2.cs
+++ b/src/KubeClient/Models/generated/StatefulSetV1Beta2.cs
@@ -11,7 +11,7 @@ namespace KubeClient.Models
     ///      - Storage: As many VolumeClaims as requested.
     ///     The StatefulSet guarantees that a given network identity will always map to the same storage identity.
     /// </summary>
-    [KubeObject("StatefulSet", "v1beta2")]
+    [KubeObject("StatefulSet", "apps/v1beta2")]
     [KubeApi(KubeAction.List, "apis/apps/v1beta2/statefulsets")]
     [KubeApi(KubeAction.WatchList, "apis/apps/v1beta2/watch/statefulsets")]
     [KubeApi(KubeAction.List, "apis/apps/v1beta2/namespaces/{namespace}/statefulsets")]

--- a/src/KubeClient/Models/generated/StorageClassListV1.cs
+++ b/src/KubeClient/Models/generated/StorageClassListV1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     StorageClassList is a collection of storage classes.
     /// </summary>
-    [KubeListItem("StorageClass", "v1")]
-    [KubeObject("StorageClassList", "v1")]
+    [KubeListItem("StorageClass", "storage.k8s.io/v1")]
+    [KubeObject("StorageClassList", "storage.k8s.io/v1")]
     public partial class StorageClassListV1 : KubeResourceListV1<StorageClassV1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/StorageClassListV1Beta1.cs
+++ b/src/KubeClient/Models/generated/StorageClassListV1Beta1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     StorageClassList is a collection of storage classes.
     /// </summary>
-    [KubeListItem("StorageClass", "v1beta1")]
-    [KubeObject("StorageClassList", "v1beta1")]
+    [KubeListItem("StorageClass", "storage.k8s.io/v1beta1")]
+    [KubeObject("StorageClassList", "storage.k8s.io/v1beta1")]
     public partial class StorageClassListV1Beta1 : KubeResourceListV1<StorageClassV1Beta1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/StorageClassV1.cs
+++ b/src/KubeClient/Models/generated/StorageClassV1.cs
@@ -10,7 +10,7 @@ namespace KubeClient.Models
     ///     
     ///     StorageClasses are non-namespaced; the name of the storage class according to etcd is in ObjectMeta.Name.
     /// </summary>
-    [KubeObject("StorageClass", "v1")]
+    [KubeObject("StorageClass", "storage.k8s.io/v1")]
     [KubeApi(KubeAction.List, "apis/storage.k8s.io/v1/storageclasses")]
     [KubeApi(KubeAction.Create, "apis/storage.k8s.io/v1/storageclasses")]
     [KubeApi(KubeAction.Get, "apis/storage.k8s.io/v1/storageclasses/{name}")]

--- a/src/KubeClient/Models/generated/StorageClassV1Beta1.cs
+++ b/src/KubeClient/Models/generated/StorageClassV1Beta1.cs
@@ -10,7 +10,7 @@ namespace KubeClient.Models
     ///     
     ///     StorageClasses are non-namespaced; the name of the storage class according to etcd is in ObjectMeta.Name.
     /// </summary>
-    [KubeObject("StorageClass", "v1beta1")]
+    [KubeObject("StorageClass", "storage.k8s.io/v1beta1")]
     [KubeApi(KubeAction.List, "apis/storage.k8s.io/v1beta1/storageclasses")]
     [KubeApi(KubeAction.Create, "apis/storage.k8s.io/v1beta1/storageclasses")]
     [KubeApi(KubeAction.Get, "apis/storage.k8s.io/v1beta1/storageclasses/{name}")]

--- a/src/KubeClient/Models/generated/SubjectAccessReviewV1.cs
+++ b/src/KubeClient/Models/generated/SubjectAccessReviewV1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     SubjectAccessReview checks whether or not a user or group can perform an action.
     /// </summary>
-    [KubeObject("SubjectAccessReview", "v1")]
+    [KubeObject("SubjectAccessReview", "authorization.k8s.io/v1")]
     [KubeApi(KubeAction.Create, "apis/authorization.k8s.io/v1/subjectaccessreviews")]
     public partial class SubjectAccessReviewV1 : KubeResourceV1
     {

--- a/src/KubeClient/Models/generated/SubjectAccessReviewV1Beta1.cs
+++ b/src/KubeClient/Models/generated/SubjectAccessReviewV1Beta1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     SubjectAccessReview checks whether or not a user or group can perform an action.
     /// </summary>
-    [KubeObject("SubjectAccessReview", "v1beta1")]
+    [KubeObject("SubjectAccessReview", "authorization.k8s.io/v1beta1")]
     [KubeApi(KubeAction.Create, "apis/authorization.k8s.io/v1beta1/subjectaccessreviews")]
     public partial class SubjectAccessReviewV1Beta1 : KubeResourceV1
     {

--- a/src/KubeClient/Models/generated/TokenReviewV1.cs
+++ b/src/KubeClient/Models/generated/TokenReviewV1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.
     /// </summary>
-    [KubeObject("TokenReview", "v1")]
+    [KubeObject("TokenReview", "authentication.k8s.io/v1")]
     [KubeApi(KubeAction.Create, "apis/authentication.k8s.io/v1/tokenreviews")]
     public partial class TokenReviewV1 : KubeResourceV1
     {

--- a/src/KubeClient/Models/generated/TokenReviewV1Beta1.cs
+++ b/src/KubeClient/Models/generated/TokenReviewV1Beta1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.
     /// </summary>
-    [KubeObject("TokenReview", "v1beta1")]
+    [KubeObject("TokenReview", "authentication.k8s.io/v1beta1")]
     [KubeApi(KubeAction.Create, "apis/authentication.k8s.io/v1beta1/tokenreviews")]
     public partial class TokenReviewV1Beta1 : KubeResourceV1
     {

--- a/src/KubeClient/Models/generated/ValidatingWebhookConfigurationListV1Beta1.cs
+++ b/src/KubeClient/Models/generated/ValidatingWebhookConfigurationListV1Beta1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     ValidatingWebhookConfigurationList is a list of ValidatingWebhookConfiguration.
     /// </summary>
-    [KubeListItem("ValidatingWebhookConfiguration", "v1beta1")]
-    [KubeObject("ValidatingWebhookConfigurationList", "v1beta1")]
+    [KubeListItem("ValidatingWebhookConfiguration", "admissionregistration.k8s.io/v1beta1")]
+    [KubeObject("ValidatingWebhookConfigurationList", "admissionregistration.k8s.io/v1beta1")]
     public partial class ValidatingWebhookConfigurationListV1Beta1 : KubeResourceListV1<ValidatingWebhookConfigurationV1Beta1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/ValidatingWebhookConfigurationV1Beta1.cs
+++ b/src/KubeClient/Models/generated/ValidatingWebhookConfigurationV1Beta1.cs
@@ -8,7 +8,7 @@ namespace KubeClient.Models
     /// <summary>
     ///     ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it.
     /// </summary>
-    [KubeObject("ValidatingWebhookConfiguration", "v1beta1")]
+    [KubeObject("ValidatingWebhookConfiguration", "admissionregistration.k8s.io/v1beta1")]
     [KubeApi(KubeAction.List, "apis/admissionregistration.k8s.io/v1beta1/validatingwebhookconfigurations")]
     [KubeApi(KubeAction.Create, "apis/admissionregistration.k8s.io/v1beta1/validatingwebhookconfigurations")]
     [KubeApi(KubeAction.Get, "apis/admissionregistration.k8s.io/v1beta1/validatingwebhookconfigurations/{name}")]

--- a/src/KubeClient/Models/generated/VolumeAttachmentListV1Alpha1.cs
+++ b/src/KubeClient/Models/generated/VolumeAttachmentListV1Alpha1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     VolumeAttachmentList is a collection of VolumeAttachment objects.
     /// </summary>
-    [KubeListItem("VolumeAttachment", "v1alpha1")]
-    [KubeObject("VolumeAttachmentList", "v1alpha1")]
+    [KubeListItem("VolumeAttachment", "storage.k8s.io/v1alpha1")]
+    [KubeObject("VolumeAttachmentList", "storage.k8s.io/v1alpha1")]
     public partial class VolumeAttachmentListV1Alpha1 : KubeResourceListV1<VolumeAttachmentV1Alpha1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/VolumeAttachmentListV1Beta1.cs
+++ b/src/KubeClient/Models/generated/VolumeAttachmentListV1Beta1.cs
@@ -8,8 +8,8 @@ namespace KubeClient.Models
     /// <summary>
     ///     VolumeAttachmentList is a collection of VolumeAttachment objects.
     /// </summary>
-    [KubeListItem("VolumeAttachment", "v1beta1")]
-    [KubeObject("VolumeAttachmentList", "v1beta1")]
+    [KubeListItem("VolumeAttachment", "storage.k8s.io/v1beta1")]
+    [KubeObject("VolumeAttachmentList", "storage.k8s.io/v1beta1")]
     public partial class VolumeAttachmentListV1Beta1 : KubeResourceListV1<VolumeAttachmentV1Beta1>
     {
         /// <summary>

--- a/src/KubeClient/Models/generated/VolumeAttachmentV1Alpha1.cs
+++ b/src/KubeClient/Models/generated/VolumeAttachmentV1Alpha1.cs
@@ -10,7 +10,7 @@ namespace KubeClient.Models
     ///     
     ///     VolumeAttachment objects are non-namespaced.
     /// </summary>
-    [KubeObject("VolumeAttachment", "v1alpha1")]
+    [KubeObject("VolumeAttachment", "storage.k8s.io/v1alpha1")]
     [KubeApi(KubeAction.List, "apis/storage.k8s.io/v1alpha1/volumeattachments")]
     [KubeApi(KubeAction.Create, "apis/storage.k8s.io/v1alpha1/volumeattachments")]
     [KubeApi(KubeAction.Get, "apis/storage.k8s.io/v1alpha1/volumeattachments/{name}")]

--- a/src/KubeClient/Models/generated/VolumeAttachmentV1Beta1.cs
+++ b/src/KubeClient/Models/generated/VolumeAttachmentV1Beta1.cs
@@ -10,7 +10,7 @@ namespace KubeClient.Models
     ///     
     ///     VolumeAttachment objects are non-namespaced.
     /// </summary>
-    [KubeObject("VolumeAttachment", "v1beta1")]
+    [KubeObject("VolumeAttachment", "storage.k8s.io/v1beta1")]
     [KubeApi(KubeAction.List, "apis/storage.k8s.io/v1beta1/volumeattachments")]
     [KubeApi(KubeAction.Create, "apis/storage.k8s.io/v1beta1/volumeattachments")]
     [KubeApi(KubeAction.Get, "apis/storage.k8s.io/v1beta1/volumeattachments/{name}")]

--- a/src/Swagger/generate_models.py
+++ b/src/Swagger/generate_models.py
@@ -46,6 +46,10 @@ class KubeModel(object):
         self.api_version = api_version
         self.pretty_api_version = pretty_api_version
         self.kube_group = kube_group
+        if self.kube_group:
+            self.api_groupversion = '{0}/{1}'.format(self.kube_group, self.api_version)
+        else:
+            self.api_groupversion = self.api_version
         self.clr_name = self.name + self.pretty_api_version
         self.summary = summary or 'No summary provided'
         self.properties = {}
@@ -519,14 +523,14 @@ def main():
 
                 model_annotations.append('    [KubeListItem("{0}", "{1}")]{2}'.format(
                     list_item_model.name,
-                    list_item_model.api_version,
+                    list_item_model.api_groupversion,
                     LINE_ENDING
                 ))
 
             if model.is_kube_resource() or model.is_kube_resource_list():
                 model_annotations.append('    [KubeObject("{0}", "{1}")]{2}'.format(
                     model.name,
-                    model.api_version,
+                    model.api_groupversion,
                     LINE_ENDING
                 ))
 

--- a/test/KubeClient.Tests/KubeObjectTests.cs
+++ b/test/KubeClient.Tests/KubeObjectTests.cs
@@ -28,7 +28,7 @@ namespace KubeClient.Tests
         ///     Verify that KubeObjectV1 correctly populates Kind and ApiVersion when constructed.
         /// </summary>
         [InlineData(typeof(DeleteOptionsV1), "DeleteOptions", "v1")]
-        [InlineData(typeof(DeploymentV1Beta1), "Deployment", "v1beta1")]
+        [InlineData(typeof(DeploymentV1Beta1), "Deployment", "apps/v1beta1")]
         [Theory(DisplayName = "KubeObjectV1 correctly populates Kind and ApiVersion ")]
         public void KubeObjectV1_Kind_Success(Type kubeObjectType, string expectedKind, string expectedApiVersion)
         {


### PR DESCRIPTION
Relates to tintoy/dotnet-kube-client#38.

CC: @bastianeicher @felixfbecker