### PR TITLE
Adds support for initial access token

### DIFF
--- a/src/KubeClient/KubeApiClient.cs
+++ b/src/KubeClient/KubeApiClient.cs
@@ -133,20 +133,22 @@ namespace KubeClient
             
             var clientBuilder = new ClientBuilder();
 
-            if (!String.IsNullOrWhiteSpace(options.AccessToken))
+            if (options.AuthStrategy == AuthStrategy.StaticBearerToken)
             {
                 clientBuilder = clientBuilder.AddHandler(
                     () => new StaticBearerTokenHandler(options.AccessToken)
                 );
             }
-            else if (!String.IsNullOrWhiteSpace(options.AccessTokenCommand))
+            else if (options.AuthStrategy == AuthStrategy.RefreshableBearerToken)
             {
                 clientBuilder = clientBuilder.AddHandler(
                     () => new CommandBearerTokenHandler(
                         accessTokenCommand: options.AccessTokenCommand,
                         accessTokenCommandArguments: options.AccessTokenCommandArguments,
                         accessTokenSelector: options.AccessTokenSelector,
-                        accessTokenExpirySelector: options.AccessTokenExpirySelector
+                        accessTokenExpirySelector: options.AccessTokenExpirySelector,
+                        initialAccessToken: options.InitialAccessToken,
+                        initialTokenExpiry: options.InitialTokenExpiry
                     )
                 );
             }

--- a/src/KubeClient/KubeClientOptions.cs
+++ b/src/KubeClient/KubeClientOptions.cs
@@ -66,6 +66,21 @@ namespace KubeClient
         ///     The Go-style selector used to retrieve the access token's expiry date/time from the command output.
         /// </summary>
         public string AccessTokenExpirySelector { get; set; }
+        
+        /// <summary>
+        ///     The initial access token used to authenticate to the Kubernetes API.
+        /// </summary>
+        public string InitialAccessToken { get; set; }
+        
+        /// <summary>
+        ///     The initial token expiry used to authenticate to the Kubernetes API.
+        /// </summary>
+        public string InitialTokenExpiry { get; set; }
+        
+        /// <summary>
+        ///     The strategy used for authenticating to the Kubernetes API.
+        /// </summary>
+        public AuthStrategy AuthStrategy { get; set; }
 
         /// <summary>
         ///     The client certificate used to authenticate to the Kubernetes API.
@@ -170,5 +185,12 @@ namespace KubeClient
                 CertificationAuthorityCertificate = kubeCACertificate
             };
         }
+    }
+
+    public enum AuthStrategy
+    {
+        None,
+        StaticBearerToken,
+        RefreshableBearerToken
     }
 }


### PR DESCRIPTION
Introduces additional properties in KubeClientOptions for initial access token and initial token expiry. Furthermore, another additional property for the authentication strategy is introduced which is set during the mapping from KubeConfig to KubeClientOptions and is considered during KubeClientApi instantiation.