### PR TITLE
Add AddKubeClient() overload that accepts IConfiguration

### DIFF
--- a/src/KubeClient.Extensions.DependencyInjection/ClientRegistrationExtensions.cs
+++ b/src/KubeClient.Extensions.DependencyInjection/ClientRegistrationExtensions.cs
@@ -110,7 +110,10 @@ namespace KubeClient
             configuration.Bind(options);
 
             if (options.ApiEndPoint == null)
+            {
                 options = KubeClientOptions.FromPodServiceAccount();
+                configuration.Bind(options);
+            }
 
             services.AddKubeClient(options);
 

--- a/src/KubeClient.Extensions.DependencyInjection/ClientRegistrationExtensions.cs
+++ b/src/KubeClient.Extensions.DependencyInjection/ClientRegistrationExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
 using System.Linq;
+using Microsoft.Extensions.Configuration;
 
 namespace KubeClient
 {
@@ -90,6 +91,28 @@ namespace KubeClient
 
             services.AddScoped<KubeApiClient>(ResolveWithOptions);
             services.AddScoped<IKubeApiClient>(ResolveWithOptions);
+
+            return services;
+        }
+
+        /// <summary>
+        ///     Add a <see cref="KubeApiClient" /> to the service collection. Automatically use a pod service account if no API endpoint is configured.
+        /// </summary>
+        /// <param name="services">
+        ///     The service collection to configure.
+        /// </param>
+        /// <param name="configuration">
+        ///     Configuration to be deserialized as <see cref="KubeClientOptions"/>.
+        /// </param>
+        public static IServiceCollection AddKubeClient(this IServiceCollection services, IConfiguration configuration)
+        {
+            var options = new KubeClientOptions();
+            configuration.Bind(options);
+
+            if (options.ApiEndPoint == null)
+                options = KubeClientOptions.FromPodServiceAccount();
+
+            services.AddKubeClient(options);
 
             return services;
         }

--- a/src/KubeClient.Extensions.DependencyInjection/KubeClient.Extensions.DependencyInjection.csproj
+++ b/src/KubeClient.Extensions.DependencyInjection/KubeClient.Extensions.DependencyInjection.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
       <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Automatically use a pod service account if no API endpoint is configured. This simplifies building services that run in Kubernetes clusters by default while allowing an easy override for local testing.

Example:

In `Startup.cs`:
```csharp
services.AddKubeClient(Configuration.GetSection("Kubernetes"))
```

In `appsettings.json`:
```json
{
  "Kubernetes": {
    "KubeNamespace": "mynamespace"
  }
}
```

In `launchSettings.json`:
```json
{
  "profiles": {
    "MyService": {
      "commandName": "Project",
      "environmentVariables": {
        "Kubernetes__ApiEndPoint": "http://localhost:8001/"
      }
    }
  }
}
```