### PR TITLE
Use CamelCase resolver for JSON serialization

### DIFF
--- a/src/KubeClient/ResourceClients/KubeResourceClient.cs
+++ b/src/KubeClient/ResourceClients/KubeResourceClient.cs
@@ -14,6 +14,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
 
 namespace KubeClient.ResourceClients
 {
@@ -45,6 +46,7 @@ namespace KubeClient.ResourceClients
         /// </summary>
         protected internal static JsonSerializerSettings SerializerSettings => new JsonSerializerSettings
         {
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
             Converters =
             {
                 new StringEnumConverter()


### PR DESCRIPTION
This makes most of the `JsonProperty` attributes unnecessary. This is especially useful when serializing 3rd party DTO classes as Kubernetes Custom Resources.