### PR TITLE
Exclude null values in JSON serialization

### DIFF
--- a/src/KubeClient/ResourceClients/KubeResourceClient.cs
+++ b/src/KubeClient/ResourceClients/KubeResourceClient.cs
@@ -46,6 +46,7 @@ namespace KubeClient.ResourceClients
         /// </summary>
         protected internal static JsonSerializerSettings SerializerSettings => new JsonSerializerSettings
         {
+            NullValueHandling = NullValueHandling.Ignore,
             ContractResolver = new CamelCasePropertyNamesContractResolver(),
             Converters =
             {


### PR DESCRIPTION
This makes the serialized output shorter and more readable.

It also seems to avoid some validation issues with Custom Resource Definitions. (The API server rejects `null` for optional `string` type fields.)