### PR TITLE
Fix case handling for configuration extension

### DIFF
--- a/samples/ExtensionsSample/ExtensionsSample.csproj
+++ b/samples/ExtensionsSample/ExtensionsSample.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\KubeClient.Extensions.Configuration\KubeClient.Extensions.Configuration.csproj" />
+    <ProjectReference Include="..\..\src\KubeClient\KubeClient.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/ExtensionsSample/ExtensionsSample.sln
+++ b/samples/ExtensionsSample/ExtensionsSample.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExtensionsSample", "ExtensionsSample.csproj", "{7C04584D-0F18-473A-88C7-CC3521968C6F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KubeClient", "..\..\src\KubeClient\KubeClient.csproj", "{12D138B4-F084-4646-9B91-1D15BFDBB4AB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KubeClient.Extensions.Configuration", "..\..\src\KubeClient.Extensions.Configuration\KubeClient.Extensions.Configuration.csproj", "{777E3F41-B044-4871-8BBA-F5227D2F4943}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7C04584D-0F18-473A-88C7-CC3521968C6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C04584D-0F18-473A-88C7-CC3521968C6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C04584D-0F18-473A-88C7-CC3521968C6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7C04584D-0F18-473A-88C7-CC3521968C6F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12D138B4-F084-4646-9B91-1D15BFDBB4AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12D138B4-F084-4646-9B91-1D15BFDBB4AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12D138B4-F084-4646-9B91-1D15BFDBB4AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12D138B4-F084-4646-9B91-1D15BFDBB4AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{777E3F41-B044-4871-8BBA-F5227D2F4943}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{777E3F41-B044-4871-8BBA-F5227D2F4943}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{777E3F41-B044-4871-8BBA-F5227D2F4943}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{777E3F41-B044-4871-8BBA-F5227D2F4943}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BB796CA0-F4BD-4487-836F-D04184247314}
+	EndGlobalSection
+EndGlobal

--- a/samples/ExtensionsSample/Program.cs
+++ b/samples/ExtensionsSample/Program.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Linq;
+using KubeClient;
+using KubeClient.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+
+namespace ExtensionsSample
+{
+    class Thing
+    {
+        public string Environment { get; set; }
+        public NestedThing Nested { get; set; }
+    }
+
+    class NestedThing
+    {
+        public string Name { get; set; }
+        public string Other { get; set; }
+    }
+
+    /// <summary>
+    /// Make sure to run: <code>kubectl apply -f ./thing-configmap.yaml</code> to create the extensions-sample configMap before running this sample.  You also need to be running <code>kubectl proxy</code>
+    /// </summary>
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var configBuilder = new ConfigurationBuilder();
+            using (var client = KubeApiClient.Create("http://localhost:8001"))
+            {
+                configBuilder.AddKubeConfigMap(client, "extensions-sample", reloadOnChange: true);
+
+                var root = configBuilder.Build();
+                var thing = new Thing();
+                root.GetSection("Thing").Bind(thing);
+                Console.WriteLine("Thing: {0}", JsonConvert.SerializeObject(thing, Formatting.Indented));
+            }
+        }
+    }
+}

--- a/samples/ExtensionsSample/thing-configmap.yaml
+++ b/samples/ExtensionsSample/thing-configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: extensions-sample
+  labels:
+    name: extensions-sample
+data:
+  thing.environment: 'kubed'
+  thing.nested.Name: 'I''m nested'
+  thing.Nested.other: 'what?'
+

--- a/src/KubeClient.Extensions.Configuration/ConfigMapConfigurationProvider.cs
+++ b/src/KubeClient.Extensions.Configuration/ConfigMapConfigurationProvider.cs
@@ -104,7 +104,8 @@ namespace KubeClient.Extensions.Configuration
                 
                 Data = configMap.Data.ToDictionary(
                     entry => sectionNamePrefix + entry.Key.Replace('.', ':'),
-                    entry => entry.Value
+                    entry => entry.Value, 
+                    StringComparer.OrdinalIgnoreCase
                 );
             }
             else

--- a/src/KubeClient.Extensions.Configuration/SecretConfigurationProvider.cs
+++ b/src/KubeClient.Extensions.Configuration/SecretConfigurationProvider.cs
@@ -126,7 +126,8 @@ namespace KubeClient.Extensions.Configuration
 
                             return entry.Value;
                         }
-                    }
+                    },
+                    StringComparer.OrdinalIgnoreCase
                 );
             }
             else


### PR DESCRIPTION
Per aspnet core configuration conventions, [keys should be case-insensitive](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-2.2#conventions).

Looking in the ConfigurationProvider base class that ConfigMapConfigurationProvider and SecretConfigurationProvider derive from, they create the Data dictionary like: `this.Data = (IDictionary<string, string>) new Dictionary<string, string>((IEqualityComparer<string>) StringComparer.OrdinalIgnoreCase);`.  I modified the providers to specify the same equality comparer

I also added an ExtensionsSample to show the configuration extension usage with a sample showing nesting and using the new case-insensitivity.
