### PR TITLE
Fix for Int32OrStringV1Converter

### DIFF
--- a/src/KubeClient/Models/Converters/Int32OrStringV1Converter.cs
+++ b/src/KubeClient/Models/Converters/Int32OrStringV1Converter.cs
@@ -72,15 +72,11 @@ namespace KubeClient.Models.Converters
                 }
                 case JsonToken.Integer:
                 {
-                    return new Int32OrStringV1(
-                        reader.ReadAsInt32().Value
-                    );
+                    return new Int32OrStringV1((int)(long)reader.Value);
                 }
                 case JsonToken.String:
                 {
-                    return new Int32OrStringV1(
-                        reader.ReadAsString()
-                    );
+                    return new Int32OrStringV1((string)reader.Value);
                 }
                 default:
                 {

--- a/test/KubeClient.Tests/JsonSerializationTests.cs
+++ b/test/KubeClient.Tests/JsonSerializationTests.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -83,6 +84,42 @@ namespace KubeClient.Tests
                 Assert.Contains(expectedPropertyName, actualPropertyNames);
             else
                 Assert.DoesNotContain(expectedPropertyName, actualPropertyNames);
+        }
+
+        [Fact]
+        public void Int32OrStringWithNullDeserializesCorrectly()
+        {
+            var json = "{ \"path\": \"/healthz\", \"port\": null, \"scheme\": \"HTTP\" }";
+            var httpGetAction = JsonConvert.DeserializeObject<HTTPGetActionV1>(json);
+            Assert.NotNull(httpGetAction);
+            Assert.Equal("/healthz", httpGetAction.Path);
+            Assert.Null(httpGetAction.Port);
+            Assert.Equal("HTTP", httpGetAction.Scheme);
+        }
+
+        [Fact]
+        public void Int32OrStringWithIntegerDeserializesCorrectly()
+        {
+            var json = "{ \"path\": \"/healthz\", \"port\": 10254, \"scheme\": \"HTTP\" }";
+            var httpGetAction = JsonConvert.DeserializeObject<HTTPGetActionV1>(json);
+            Assert.NotNull(httpGetAction);
+            Assert.Equal("/healthz", httpGetAction.Path);
+            Assert.True(httpGetAction.Port.IsInt32);
+            Assert.False(httpGetAction.Port.IsString);
+            Assert.Equal(10254, httpGetAction.Port.Int32Value);
+            Assert.Equal("HTTP", httpGetAction.Scheme);
+        }
+
+        [Fact]
+        public void Int32OrStringWithStringDeserializesCorrectly()
+        {
+            var json = "{ \"path\": \"/healthz\", \"port\": \"http\", \"scheme\": \"HTTP\" }";
+            var httpGetAction = JsonConvert.DeserializeObject<HTTPGetActionV1>(json);
+            Assert.NotNull(httpGetAction);
+            Assert.False(httpGetAction.Port.IsInt32);
+            Assert.True(httpGetAction.Port.IsString);
+            Assert.Equal("http", httpGetAction.Port.StringValue);
+            Assert.Equal("HTTP", httpGetAction.Scheme);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes: https://github.com/tintoy/dotnet-kube-client/issues/70

- reader.ReadAsInt32() wasn't working
- also appears you shouldn't advance reader inside a json converter
- Added some basic unit tests