### PR TITLE
Respect custom JsonSerializerSettings when parsing responses

### DIFF
--- a/src/KubeClient/ResourceClients/DynamicResourceClient.cs
+++ b/src/KubeClient/ResourceClients/DynamicResourceClient.cs
@@ -118,7 +118,7 @@ namespace KubeClient.ResourceClients
                     using (Stream responseStream = await responseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false))
                     using (TextReader responseReader = new StreamReader(responseStream))
                     {
-                        JsonSerializer serializer = JsonSerializer.Create(SerializerSettings);
+                        JsonSerializer serializer = responseMessage.GetJsonSerializer();
 
                         return (KubeResourceV1)serializer.Deserialize(responseReader, modelType);
                     }
@@ -179,7 +179,7 @@ namespace KubeClient.ResourceClients
                     using (Stream responseStream = await responseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false))
                     using (TextReader responseReader = new StreamReader(responseStream))
                     {
-                        JsonSerializer serializer = JsonSerializer.Create(SerializerSettings);
+                        JsonSerializer serializer = responseMessage.GetJsonSerializer();
 
                         return (KubeResourceListV1)serializer.Deserialize(responseReader, listModelType);
                     }
@@ -253,7 +253,7 @@ namespace KubeClient.ResourceClients
                     using (Stream responseStream = await responseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false))
                     using (TextReader responseReader = new StreamReader(responseStream))
                     {
-                        JsonSerializer serializer = JsonSerializer.Create(SerializerSettings);
+                        JsonSerializer serializer = responseMessage.GetJsonSerializer();
 
                         return (KubeResourceV1)serializer.Deserialize(responseReader, modelType);
                     }

--- a/src/KubeClient/ResourceClients/KubeResourceClient.cs
+++ b/src/KubeClient/ResourceClients/KubeResourceClient.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using System;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -410,12 +411,14 @@ namespace KubeClient.ResourceClients
             if (String.IsNullOrWhiteSpace(operationDescription))
                 throw new ArgumentException("Argument cannot be null, empty, or entirely composed of whitespace: 'operationDescription'.", nameof(operationDescription));
 
+            JsonSerializerSettings serializerSettings = request.GetFormatters().Values.GetJsonSerializerSettings();
+
             return ObserveLines(request, operationDescription)
                 .Do(
                     line => CheckForEventError(line, operationDescription)
                 )
                 .Select(
-                    line => (IResourceEventV1<TResource>) JsonConvert.DeserializeObject<ResourceEventV1<TResource>>(line, SerializerSettings)
+                    line => (IResourceEventV1<TResource>) JsonConvert.DeserializeObject<ResourceEventV1<TResource>>(line, serializerSettings)
                 );
         }
 


### PR DESCRIPTION
This makes it possible to e.g. register custom `JsonConverter`s for use with CRDs.