### PR TITLE
Non-base64 encoded tokens in config

### DIFF
--- a/src/KubeClient.Extensions.KubeConfig/Models/UserIdentityConfig.cs
+++ b/src/KubeClient.Extensions.KubeConfig/Models/UserIdentityConfig.cs
@@ -61,11 +61,18 @@ namespace KubeClient.Extensions.KubeConfig.Models
             if (String.IsNullOrWhiteSpace(Token))
                 return null;
 
-            string token = Encoding.ASCII.GetString(
-                Convert.FromBase64String(Token)
-            );
-            if (token.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
-                return token.Substring("Bearer ".Length);
+            try
+            {
+                string token = Encoding.ASCII.GetString(
+                    Convert.FromBase64String(Token)
+                );
+                if (token.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                    return token.Substring("Bearer ".Length);
+            }
+            catch (FormatException)
+            {
+                // ignored in case the string is not base64 encoded.  There's no good/reliable way to say for sure that a string is base64 encoded ('abcd' is technically a valid base64 string)
+            }
 
             return Token;
         }


### PR DESCRIPTION
- Assuming only bearer strings are base64 encoded, non-encoded tokens are throwing exception on Convert.FromBase64String() since they're not valid base64 strings

Attempt to fix #80.  I'm not 100% sure that bearer strings are the only case that's bas64 encoded, but when I tried to simply base64 encode the token in my config file, kubectl fails to authenticate.