### PR TITLE
Add support for server-side apply

### DIFF
--- a/src/KubeClient/Models/Yaml.cs
+++ b/src/KubeClient/Models/Yaml.cs
@@ -22,17 +22,17 @@ namespace KubeClient.Models
         /// <summary>
         ///     The singleton YAML <see cref="Deserializer"/> used by static methods on <see cref="Yaml"/>.
         /// </summary>
-        static readonly Deserializer YamlDeserialiser = new DeserializerBuilder().IgnoreUnmatchedProperties().Build();
+        static readonly IDeserializer YamlDeserialiser = new DeserializerBuilder().IgnoreUnmatchedProperties().Build();
 
         /// <summary>
         ///     The singleton YAML <see cref="Serializer"/> used by static methods on <see cref="Yaml"/>.
         /// </summary>
-        static readonly Serializer YamlSerialiser = new SerializerBuilder().Build();
+        static readonly ISerializer YamlSerialiser = new SerializerBuilder().Build();
 
         /// <summary>
         ///     The singleton (JSON-compatible) YAML <see cref="Serializer"/> used by static methods on <see cref="Yaml"/>.
         /// </summary>
-        static readonly Serializer YamlJsonSerialiser = new SerializerBuilder().JsonCompatible().Build();
+        static readonly ISerializer YamlJsonSerialiser = new SerializerBuilder().JsonCompatible().Build();
 
         /// <summary>
         ///     The singleton <see cref="JsonSerializer"/> used by static methods on <see cref="Yaml"/>.

--- a/src/KubeClient/ResourceClients/DynamicResourceClient.cs
+++ b/src/KubeClient/ResourceClients/DynamicResourceClient.cs
@@ -1,3 +1,4 @@
+
 using HTTPlease;
 using Microsoft.AspNetCore.JsonPatch;
 using Newtonsoft.Json;
@@ -300,8 +301,6 @@ namespace KubeClient.ResourceClients
             if (resource == null)
                 throw new ArgumentNullException(nameof(resource));
 
-            // TODO: Consider making the "fieldManager" parameter optional if we can automatically infer it by inspecting ObjectMetaV1.ExtensionData["managedFields"].
-
             if (String.IsNullOrWhiteSpace(fieldManager))
                 throw new ArgumentException($"Argument cannot be null, empty, or entirely composed of whitespace: {nameof(fieldManager)}.", nameof(fieldManager));
 
@@ -342,6 +341,94 @@ namespace KubeClient.ResourceClients
                     string name = resource.Metadata.Name;
                     string kubeNamespace = resource.Metadata.Namespace;
 
+                    string errorMessage = isNamespaced ?
+                        $"Unable to patch {apiVersion}/{kind} resource '{name}' in namespace '{kubeNamespace}' using server-side apply (resource not found)."
+                        :
+                        $"Unable to patch {apiVersion}/{kind} resource '{name}' using server-side apply (resource not found).";
+
+                    throw new KubeClientException(errorMessage);
+                }
+
+                throw new KubeClientException($"Unable to patch {apiVersion}/{kind} resource (HTTP status {responseMessage.StatusCode}).",
+                    innerException: new HttpRequestException<StatusV1>(responseMessage.StatusCode, status)
+                );
+            }
+        }
+
+        /// <summary>
+        ///     Update a Kubernetes resource using a server-side apply operation with the specified YAML.
+        /// </summary>
+        /// <param name="name">
+        ///     The resource name.
+        /// </param>
+        /// <param name="kind">
+        ///     The resource kind.
+        /// </param>
+        /// <param name="apiVersion">
+        ///     The resource API version.
+        /// </param>
+        /// <param name="yaml">
+        ///     A string containing the resource YAML.
+        /// </param>
+        /// <param name="fieldManager">
+        ///     The name of the field manager to use when performing the server-side apply.
+        /// </param>
+        /// <param name="kubeNamespace">
+        ///     The (optional) name of a Kubernetes namespace containing the resources.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     An optional <see cref="CancellationToken"/> that can be used to cancel the request.
+        /// </param>
+        /// <returns>
+        ///     A <see cref="KubeResourceV1"/> representing the updated resource.
+        /// </returns>
+        public async Task<KubeResourceV1> ApplyYaml(string name, string kind, string apiVersion, string yaml, string fieldManager, string kubeNamespace = null, CancellationToken cancellationToken = default)
+        {
+            if (String.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("Argument cannot be null, empty, or entirely composed of whitespace: 'name'.", nameof(name));
+
+            if (String.IsNullOrWhiteSpace(kind))
+                throw new ArgumentException("Argument cannot be null, empty, or entirely composed of whitespace: 'kind'.", nameof(kind));
+
+            if (String.IsNullOrWhiteSpace(apiVersion))
+                throw new ArgumentException("Argument cannot be null, empty, or entirely composed of whitespace: 'apiVersion'.", nameof(apiVersion));
+
+            if (String.IsNullOrWhiteSpace(yaml))
+                throw new ArgumentException($"Argument cannot be null, empty, or entirely composed of whitespace: {nameof(yaml)}.", nameof(yaml));
+
+            bool isNamespaced = !String.IsNullOrWhiteSpace(kubeNamespace);
+
+            await EnsureApiMetadata(cancellationToken);
+            string apiPath = GetApiPath(kind, apiVersion, isNamespaced);
+
+            Type modelType = GetModelType(kind, apiVersion);
+
+            HttpRequest request = KubeRequest.Create(apiPath).WithRelativeUri("{name}?fieldManager={fieldManager?}")
+                .WithTemplateParameters(new
+                {
+                    name,
+                    @namespace = kubeNamespace,
+                    fieldManager
+                });
+
+            using (HttpResponseMessage responseMessage = await Http.PatchAsync(request, patchBody: new StringContent(yaml), mediaType: ApplyPatchYamlMediaType, cancellationToken: cancellationToken).ConfigureAwait(false))
+            {
+                if (responseMessage.IsSuccessStatusCode)
+                {
+                    // Code is slightly ugly for types only known at runtime; see if HTTPlease could be improved here.
+                    using (Stream responseStream = await responseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                    using (TextReader responseReader = new StreamReader(responseStream))
+                    {
+                        JsonSerializer serializer = responseMessage.GetJsonSerializer();
+
+                        return (KubeResourceV1)serializer.Deserialize(responseReader, modelType);
+                    }
+                }
+
+                // Ensure that HttpStatusCode.NotFound actually refers to the target resource.
+                StatusV1 status = await responseMessage.ReadContentAsStatusV1Async(HttpStatusCode.NotFound).ConfigureAwait(false);
+                if (status.Reason == "NotFound")
+                {
                     string errorMessage = isNamespaced ?
                         $"Unable to patch {apiVersion}/{kind} resource '{name}' in namespace '{kubeNamespace}' using server-side apply (resource not found)."
                         :
@@ -559,5 +646,55 @@ namespace KubeClient.ResourceClients
         ///     A <see cref="KubeResourceV1"/> representing the updated resource.
         /// </returns>
         Task<KubeResourceV1> Patch(string name, string kind, string apiVersion, JsonPatchDocument patch, string kubeNamespace = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Update a Kubernetes resource using a server-side apply operation.
+        /// </summary>
+        /// <typeparam name="TResource">
+        ///     The type of resource to update.
+        /// </typeparam>
+        /// <param name="resource">
+        ///     A <typeparamref name="TResource"/> representing the resource to update.
+        /// </param>
+        /// <param name="fieldManager">
+        ///     The name of the field manager to use when performing the server-side apply.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     An optional <see cref="CancellationToken"/> that can be used to cancel the request.
+        /// </param>
+        /// <returns>
+        ///     A <typeparamref name="TResource"/> representing the updated resource.
+        /// </returns>
+        Task<TResource> Apply<TResource>(TResource resource, string fieldManager, CancellationToken cancellationToken = default)
+            where TResource : KubeResourceV1;
+
+        /// <summary>
+        ///     Update a Kubernetes resource using a server-side apply operation with the specified YAML.
+        /// </summary>
+        /// <param name="name">
+        ///     The resource name.
+        /// </param>
+        /// <param name="kind">
+        ///     The resource kind.
+        /// </param>
+        /// <param name="apiVersion">
+        ///     The resource API version.
+        /// </param>
+        /// <param name="yaml">
+        ///     A string containing the resource YAML.
+        /// </param>
+        /// <param name="fieldManager">
+        ///     The name of the field manager to use when performing the server-side apply.
+        /// </param>
+        /// <param name="kubeNamespace">
+        ///     The (optional) name of a Kubernetes namespace containing the resources.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     An optional <see cref="CancellationToken"/> that can be used to cancel the request.
+        /// </param>
+        /// <returns>
+        ///     A <see cref="KubeResourceV1"/> representing the updated resource.
+        /// </returns>
+        Task<KubeResourceV1> ApplyYaml(string name, string kind, string apiVersion, string yaml, string fieldManager, string kubeNamespace = null, CancellationToken cancellationToken = default);
     }
 }

--- a/src/KubeClient/ResourceClients/DynamicResourceClient.cs
+++ b/src/KubeClient/ResourceClients/DynamicResourceClient.cs
@@ -15,6 +15,7 @@ namespace KubeClient.ResourceClients
 {
     using ApiMetadata;
     using Models;
+    using System.Text;
 
     // TODO: Always prefer namespaced API paths (except for List operations) and use client's default namespace.
 
@@ -411,7 +412,8 @@ namespace KubeClient.ResourceClients
                     fieldManager
                 });
 
-            using (HttpResponseMessage responseMessage = await Http.PatchAsync(request, patchBody: new StringContent(yaml), mediaType: ApplyPatchYamlMediaType, cancellationToken: cancellationToken).ConfigureAwait(false))
+            using (StringContent patchBody = new StringContent(yaml, Encoding.UTF8, ApplyPatchYamlMediaType))
+            using (HttpResponseMessage responseMessage = await Http.PatchAsync(request, patchBody, mediaType: ApplyPatchYamlMediaType, cancellationToken: cancellationToken).ConfigureAwait(false))
             {
                 if (responseMessage.IsSuccessStatusCode)
                 {

--- a/src/KubeClient/ResourceClients/DynamicResourceClient.cs
+++ b/src/KubeClient/ResourceClients/DynamicResourceClient.cs
@@ -290,13 +290,16 @@ namespace KubeClient.ResourceClients
         /// <param name="fieldManager">
         ///     The name of the field manager to use when performing the server-side apply.
         /// </param>
+        /// <param name="force">
+        ///     Allow the field manager to take ownership of fields if required?
+        /// </param>
         /// <param name="cancellationToken">
         ///     An optional <see cref="CancellationToken"/> that can be used to cancel the request.
         /// </param>
         /// <returns>
         ///     A <typeparamref name="TResource"/> representing the updated resource.
         /// </returns>
-        public async Task<TResource> Apply<TResource>(TResource resource, string fieldManager, CancellationToken cancellationToken = default)
+        public async Task<TResource> Apply<TResource>(TResource resource, string fieldManager, bool force = false, CancellationToken cancellationToken = default)
             where TResource : KubeResourceV1
         {
             if (resource == null)
@@ -321,6 +324,7 @@ namespace KubeClient.ResourceClients
                 resource.ApiVersion,
                 resourceYaml,
                 fieldManager,
+                force,
                 kubeNamespace: resource.Metadata.Namespace,
                 cancellationToken
             );
@@ -346,6 +350,9 @@ namespace KubeClient.ResourceClients
         /// <param name="fieldManager">
         ///     The name of the field manager to use when performing the server-side apply.
         /// </param>
+        /// <param name="force">
+        ///     Allow the field manager to take ownership of fields if required?
+        /// </param>
         /// <param name="kubeNamespace">
         ///     The (optional) name of a Kubernetes namespace containing the resources.
         /// </param>
@@ -355,7 +362,7 @@ namespace KubeClient.ResourceClients
         /// <returns>
         ///     A <see cref="KubeResourceV1"/> representing the updated resource.
         /// </returns>
-        public async Task<KubeResourceV1> ApplyYaml(string name, string kind, string apiVersion, string yaml, string fieldManager, string kubeNamespace = null, CancellationToken cancellationToken = default)
+        public async Task<KubeResourceV1> ApplyYaml(string name, string kind, string apiVersion, string yaml, string fieldManager, bool force = false, string kubeNamespace = null, CancellationToken cancellationToken = default)
         {
             if (String.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("Argument cannot be null, empty, or entirely composed of whitespace: 'name'.", nameof(name));
@@ -376,12 +383,13 @@ namespace KubeClient.ResourceClients
 
             Type modelType = GetModelType(kind, apiVersion);
 
-            HttpRequest request = KubeRequest.Create(apiPath).WithRelativeUri("{name}?fieldManager={fieldManager?}")
+            HttpRequest request = KubeRequest.Create(apiPath).WithRelativeUri("{name}?fieldManager={fieldManager?}&force={force?}")
                 .WithTemplateParameters(new
                 {
                     name,
                     @namespace = kubeNamespace,
-                    fieldManager
+                    fieldManager,
+                    force = force ? "true" : null
                 });
 
             using (StringContent patchBody = new StringContent(yaml, Encoding.UTF8, ApplyPatchYamlMediaType))
@@ -633,13 +641,16 @@ namespace KubeClient.ResourceClients
         /// <param name="fieldManager">
         ///     The name of the field manager to use when performing the server-side apply.
         /// </param>
+        /// <param name="force">
+        ///     Allow the field manager to take ownership of fields if required?
+        /// </param>
         /// <param name="cancellationToken">
         ///     An optional <see cref="CancellationToken"/> that can be used to cancel the request.
         /// </param>
         /// <returns>
         ///     A <typeparamref name="TResource"/> representing the updated resource.
         /// </returns>
-        Task<TResource> Apply<TResource>(TResource resource, string fieldManager, CancellationToken cancellationToken = default)
+        Task<TResource> Apply<TResource>(TResource resource, string fieldManager, bool force = false, CancellationToken cancellationToken = default)
             where TResource : KubeResourceV1;
 
         /// <summary>
@@ -660,6 +671,9 @@ namespace KubeClient.ResourceClients
         /// <param name="fieldManager">
         ///     The name of the field manager to use when performing the server-side apply.
         /// </param>
+        /// <param name="force">
+        ///     Allow the field manager to take ownership of fields if required?
+        /// </param>
         /// <param name="kubeNamespace">
         ///     The (optional) name of a Kubernetes namespace containing the resources.
         /// </param>
@@ -669,6 +683,6 @@ namespace KubeClient.ResourceClients
         /// <returns>
         ///     A <see cref="KubeResourceV1"/> representing the updated resource.
         /// </returns>
-        Task<KubeResourceV1> ApplyYaml(string name, string kind, string apiVersion, string yaml, string fieldManager, string kubeNamespace = null, CancellationToken cancellationToken = default);
+        Task<KubeResourceV1> ApplyYaml(string name, string kind, string apiVersion, string yaml, string fieldManager, bool force = false, string kubeNamespace = null, CancellationToken cancellationToken = default);
     }
 }

--- a/src/KubeClient/ResourceClients/KubeResourceClient.cs
+++ b/src/KubeClient/ResourceClients/KubeResourceClient.cs
@@ -44,6 +44,16 @@ namespace KubeClient.ResourceClients
         protected static readonly string MergePatchMediaType = "application/merge-patch+json";
 
         /// <summary>
+        ///     The media type used to indicate that request is a Kubernetes server-side-apply PATCH request in JSON format.
+        /// </summary>
+        protected static readonly string ApplyPatchJsonMediaType = "application/apply-patch+json";
+
+        /// <summary>
+        ///     The media type used to indicate that request is a Kubernetes server-side-apply PATCH request in YAML format.
+        /// </summary>
+        protected static readonly string ApplyPatchYamlMediaType = "application/apply-patch+yaml";
+
+        /// <summary>
         ///     JSON serialisation settings.
         /// </summary>
         public static JsonSerializerSettings SerializerSettings => new JsonSerializerSettings

--- a/test/KubeClient.Tests/ServerSideApplyTests.cs
+++ b/test/KubeClient.Tests/ServerSideApplyTests.cs
@@ -1,0 +1,81 @@
+﻿using HTTPlease.Testability;
+using Newtonsoft.Json;
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace KubeClient.Tests
+{
+    using ErrorHandling;
+    using Models;
+    using ResourceClients;
+    using TestCommon;
+
+    /// <summary>
+    ///     Integration tests for server-side apply (via <see cref="IDynamicResourceClient"/>).
+    /// </summary>
+    public class ServerSideApplyTests
+        : TestBase
+    {
+        /// <summary>
+        ///     Create a new server-side-apply test suite.
+        /// </summary>
+        /// <param name="testOutput">
+        ///     Output for the current test.
+        /// </param>
+        public ServerSideApplyTests(ITestOutputHelper testOutput)
+            : base(testOutput)
+        {
+        }
+
+        /// <summary>
+        /// Verify that server-side apply of raw YAML results in a PATCH request with the correct content type.
+        /// </summary>
+        [Fact( DisplayName = "Server-side apply of raw YAML" )]
+        public async Task ApplyYaml()
+        {
+            MockMessageHandler handler = new MockMessageHandler(request =>
+            {
+                Assert.Equal("PATCH", request.Method.Method);
+
+                Assert.NotNull(request.Content);
+                Assert.NotNull(request.Content.Headers.ContentType);
+                Assert.Equal("application/apply-patch+yaml", request.Content.Headers.ContentType.MediaType);
+
+                Assert.Contains("fieldManager=my-field-manager", request.RequestUri.Query);
+
+                return request.CreateResponse(HttpStatusCode.OK,
+                    responseBody: JsonConvert.SerializeObject(new PodV1
+                    {
+                        Metadata = new ObjectMetaV1
+                        {
+                            Name = "my-pod",
+                            Namespace = "my-namespace"
+                        }
+                    }),
+                    mediaType: "application/json"
+                );
+            });
+
+            const string podYaml = @"
+kind: Pod
+apiVersion: v1
+metadata:
+    name: my-pod
+            ";
+
+            using (KubeApiClient client = handler.CreateClient(loggerFactory: LoggerFactory))
+            {
+                await client.Dynamic().ApplyYaml(
+                    name: "my-pod",
+                    kind: "Pod",
+                    apiVersion: "v1",
+                    yaml: podYaml,
+                    fieldManager: "my-field-manager",
+                    kubeNamespace: "my-namespace"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Note - still using the Yaml serialization process described in the commit notes because JSON.NET's custom attributes are more flexible than YamlDotNet's ones (and YamlDotNet can't handle reuse of exiting collection instances in read-only properties, which better fits the KubeClient model philosophy).