### PR TITLE
Move replicaset to new API location (apps/v1)

### DIFF
--- a/src/KubeClient/ResourceClients/ReplicaSetClientV1.cs
+++ b/src/KubeClient/ResourceClients/ReplicaSetClientV1.cs
@@ -206,12 +206,12 @@ namespace KubeClient.ResourceClients
             /// <summary>
             ///     A collection-level ReplicaSet (v1) request.
             /// </summary>
-            public static readonly HttpRequest Collection   = KubeRequest.Create("/apis/extensions/v1beta1/namespaces/{Namespace}/replicasets?labelSelector={LabelSelector?}&watch={Watch?}");
+            public static readonly HttpRequest Collection   = KubeRequest.Create("/apis/apps/v1/namespaces/{Namespace}/replicasets?labelSelector={LabelSelector?}&watch={Watch?}");
 
             /// <summary>
             ///     A get-by-name ReplicaSet (v1) request.
             /// </summary>
-            public static readonly HttpRequest ByName       = KubeRequest.Create("/apis/extensions/v1beta1/namespaces/{Namespace}/replicasets/{Name}");
+            public static readonly HttpRequest ByName       = KubeRequest.Create("/apis/apps/v1/namespaces/{Namespace}/replicasets/{Name}");
         }
     }
 


### PR DESCRIPTION
Old API location was [deprecated in Kubernetes 1.16](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/).  This matches the other types that have already been moved (Daemon Set, Deployment, Stateful Set) and is backwards compatible back to Kubernetes 1.9