### PR TITLE
Support for username/passsword (basic) API Authentication

### DIFF
--- a/src/KubeClient.Extensions.KubeConfig/K8sConfig.cs
+++ b/src/KubeClient.Extensions.KubeConfig/K8sConfig.cs
@@ -203,6 +203,12 @@ namespace KubeClient
                     kubeClientOptions.AccessToken = accessToken;
                     kubeClientOptions.AuthStrategy = KubeAuthStrategy.BearerToken;
                 }
+                else if (!String.IsNullOrEmpty(targetUser.Config.Username) && !String.IsNullOrEmpty(targetUser.Config.Password))
+                {
+                    kubeClientOptions.Username = targetUser.Config.Username;
+                    kubeClientOptions.Password = targetUser.Config.Password;
+                    kubeClientOptions.AuthStrategy = KubeAuthStrategy.Basic;
+                }
                 else
                 {
                     kubeClientOptions.AuthStrategy = KubeAuthStrategy.None;

--- a/src/KubeClient.Extensions.KubeConfig/Models/UserIdentityConfig.cs
+++ b/src/KubeClient.Extensions.KubeConfig/Models/UserIdentityConfig.cs
@@ -52,6 +52,18 @@ namespace KubeClient.Extensions.KubeConfig.Models
         /// </summary>
         [YamlMember(Alias = "client-key-data")]
         public string ClientKeyData { get; set; }
+        
+        /// <summary>
+        ///     The username to use.
+        /// </summary>
+        [YamlMember(Alias = "username")]
+        public string Username { get; set; }
+
+        /// <summary>
+        ///     The password to use.
+        /// </summary>
+        [YamlMember(Alias = "password")]
+        public string Password { get; set; }
 
         /// <summary>
         ///     Get the raw Kubernetes authentication token (if any).

--- a/src/KubeClient/KubeApiClient.cs
+++ b/src/KubeClient/KubeApiClient.cs
@@ -129,6 +129,14 @@ namespace KubeClient
 
             switch (options.AuthStrategy)
             {
+                case KubeAuthStrategy.Basic:
+                {
+                    clientBuilder = clientBuilder.AddHandler(
+                        () => new BasicAuthenticationHandler(options.Username, options.Password)
+                    );
+
+                    break;
+                }
                 case KubeAuthStrategy.BearerToken:
                 {
                     clientBuilder = clientBuilder.AddHandler(

--- a/src/KubeClient/KubeClientOptions.cs
+++ b/src/KubeClient/KubeClientOptions.cs
@@ -49,6 +49,16 @@ namespace KubeClient
         public string AccessToken { get; set; }
 
         /// <summary>
+        ///     The username used to authenticate to the Kubernetes API.
+        /// </summary>
+        public string Username { get; set; }
+
+        /// <summary>
+        ///     The password used to authenticate to the Kubernetes API.
+        /// </summary>
+        public string Password { get; set; }
+
+        /// <summary>
         ///     The command used to generate an access token for authenticating to the Kubernetes API.
         /// </summary>
         public string AccessTokenCommand { get; set; }
@@ -214,6 +224,11 @@ namespace KubeClient
         ///     Client certificate (i.e. mutual SSL) authentication.
         /// </summary>
         ClientCertificate,
+
+        /// <summary>
+        ///     Username/Password authentication.
+        /// </summary>
+        Basic,
 
         /// <summary>
         ///     A pre-defined (static) bearer token.

--- a/src/KubeClient/MessageHandlers/BasicAuthenticationHandler.cs
+++ b/src/KubeClient/MessageHandlers/BasicAuthenticationHandler.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace KubeClient.MessageHandlers
+{
+    /// <summary>
+    /// Basic Authentication Handler for username/password authentication.
+    /// </summary>
+    public class BasicAuthenticationHandler : DelegatingHandler
+    {
+        readonly string _encoded;
+
+        /// <summary>
+        /// Create a new <see cref="BasicAuthenticationHandler"/>.
+        /// </summary>
+        /// <param name="username">The username to use</param>
+        /// <param name="password">The password to use</param>
+        public BasicAuthenticationHandler(string username, string password)
+        {
+            if(String.IsNullOrEmpty(username))
+                throw new ArgumentNullException(nameof(username));
+            if(String.IsNullOrEmpty(password))
+                throw new ArgumentNullException(nameof(password));
+
+            _encoded = Convert.ToBase64String(Encoding.ASCII.GetBytes(username + ":" + password));
+        }
+        
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Basic", _encoded);
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
This is a simple username/password authentication implementation.  I've verified that it works from `.kube/config` or creating options by hand.

[K3s](https://k3s.io/) uses username/password authentication by default.  If you have a strong preference to not add username/password support that's OK.  I don't strictly need this since I've tested generating a token like I mention here: https://github.com/tintoy/dotnet-kube-client/issues/80 and modifying my `.kube/config` entry.  But it would simplify my workflow quite a bit if I didn't have to do that when I recreate my k3s cluster (which happens often), and I imagine there are other username/password environments out there.