### PR TITLE
Feature/telepresence

### DIFF
--- a/src/KubeClient/KubeClientConstants.cs
+++ b/src/KubeClient/KubeClientConstants.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
+
+namespace KubeClient
+{
+    /// <summary>
+    ///     Constants for the Kubernetes API client.
+    /// </summary>
+    public static class KubeClientConstants
+    {
+        /// <summary>
+        ///     Environment Variable set in a Kubernetes Pod containing the host name of the API Service
+        /// </summary>
+        public const string KubernetesServiceHost = "KUBERNETES_SERVICE_HOST";
+        
+        /// <summary>
+        ///     Environment Variable set in a Kubernetes Pod containing the port of the API Service
+        /// </summary>
+        public const string KubernetesServicePort = "KUBERNETES_SERVICE_PORT";
+
+        /// <summary>
+        ///     Default path of mounted volume containing Kubernetes service account token and CA certificate
+        /// </summary>
+        public const string DefaultServiceAccountPath = "/var/run/secrets/kubernetes.io/serviceaccount";
+    }
+}

--- a/src/KubeClient/KubeClientOptions.cs
+++ b/src/KubeClient/KubeClientOptions.cs
@@ -21,6 +21,11 @@ namespace KubeClient
         /// Environment Variable set in a Kubernetes Pod containing the port of the API Service
         /// </summary>
         public const string KubernetesServicePort = "KUBERNETES_SERVICE_PORT";
+
+        /// <summary>
+        /// Default path of volume containing Kubernetes service account token and CA certificate
+        /// </summary>
+        public const string DefaultServiceAccountPath = "/var/run/secrets/kubernetes.io/serviceaccount";
         
         /// <summary>
         ///     Create new <see cref="KubeClientOptions"/>.
@@ -201,7 +206,7 @@ namespace KubeClient
         ///     Only works from within a container running in a Kubernetes Pod.
         /// </remarks>
         /// <exception cref="InvalidOperationException"></exception>
-        public static KubeClientOptions FromPodServiceAccount(string serviceAccountPath = "/var/run/secrets/kubernetes.io/serviceaccount")
+        public static KubeClientOptions FromPodServiceAccount(string serviceAccountPath = DefaultServiceAccountPath)
         {
             string kubeServiceHost = Environment.GetEnvironmentVariable(KubernetesServiceHost);
             string kubeServicePort = Environment.GetEnvironmentVariable(KubernetesServicePort);

--- a/src/KubeClient/KubeClientOptions.cs
+++ b/src/KubeClient/KubeClientOptions.cs
@@ -189,15 +189,19 @@ namespace KubeClient
         }
 
         /// <summary>
-        ///     Create new <see cref="KubeClientOptions"/> using pod-level configuration.
+        ///     Create new <see cref="KubeClientOptions"/> using pod-level configuration. 
         /// </summary>
+        /// <param name="serviceAccountPath">
+        ///     The location of the volume containing service account token and CA certificate 
+        /// </param>
         /// <returns>
         ///     The configured <see cref="KubeClientOptions"/>.
         /// </returns>
         /// <remarks>
         ///     Only works from within a container running in a Kubernetes Pod.
         /// </remarks>
-        public static KubeClientOptions FromPodServiceAccount()
+        /// <exception cref="InvalidOperationException"></exception>
+        public static KubeClientOptions FromPodServiceAccount(string serviceAccountPath = "/var/run/secrets/kubernetes.io/serviceaccount")
         {
             string kubeServiceHost = Environment.GetEnvironmentVariable(KubernetesServiceHost);
             string kubeServicePort = Environment.GetEnvironmentVariable(KubernetesServicePort);
@@ -205,9 +209,9 @@ namespace KubeClient
                 throw new InvalidOperationException($"KubeApiClient.CreateFromPodServiceAccount can only be called when running in a Kubernetes Pod ({KubernetesServiceHost} and/or {KubernetesServicePort} environment variable is not defined).");
 
             string apiEndPoint = $"https://{kubeServiceHost}:{kubeServicePort}/";
-            string accessToken = File.ReadAllText("/var/run/secrets/kubernetes.io/serviceaccount/token");
+            string accessToken = File.ReadAllText(Path.Combine(serviceAccountPath, "token"));
             var kubeCACertificate = new X509Certificate2(
-                File.ReadAllBytes("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+                File.ReadAllBytes(Path.Combine(serviceAccountPath, "ca.crt"))
             );
 
             return new KubeClientOptions

--- a/src/KubeClient/KubeClientOptions.cs
+++ b/src/KubeClient/KubeClientOptions.cs
@@ -13,21 +13,6 @@ namespace KubeClient
     public class KubeClientOptions
     {
         /// <summary>
-        /// Environment Variable set in a Kubernetes Pod containing the host name of the API Service
-        /// </summary>
-        public const string KubernetesServiceHost = "KUBERNETES_SERVICE_HOST";
-        
-        /// <summary>
-        /// Environment Variable set in a Kubernetes Pod containing the port of the API Service
-        /// </summary>
-        public const string KubernetesServicePort = "KUBERNETES_SERVICE_PORT";
-
-        /// <summary>
-        /// Default path of volume containing Kubernetes service account token and CA certificate
-        /// </summary>
-        public const string DefaultServiceAccountPath = "/var/run/secrets/kubernetes.io/serviceaccount";
-        
-        /// <summary>
         ///     Create new <see cref="KubeClientOptions"/>.
         /// </summary>
         public KubeClientOptions()
@@ -206,12 +191,12 @@ namespace KubeClient
         ///     Only works from within a container running in a Kubernetes Pod.
         /// </remarks>
         /// <exception cref="InvalidOperationException"></exception>
-        public static KubeClientOptions FromPodServiceAccount(string serviceAccountPath = DefaultServiceAccountPath)
+        public static KubeClientOptions FromPodServiceAccount(string serviceAccountPath = KubeClientConstants.DefaultServiceAccountPath)
         {
-            string kubeServiceHost = Environment.GetEnvironmentVariable(KubernetesServiceHost);
-            string kubeServicePort = Environment.GetEnvironmentVariable(KubernetesServicePort);
+            string kubeServiceHost = Environment.GetEnvironmentVariable(KubeClientConstants.KubernetesServiceHost);
+            string kubeServicePort = Environment.GetEnvironmentVariable(KubeClientConstants.KubernetesServicePort);
             if (String.IsNullOrWhiteSpace(kubeServiceHost) || String.IsNullOrWhiteSpace(kubeServicePort))
-                throw new InvalidOperationException($"KubeApiClient.CreateFromPodServiceAccount can only be called when running in a Kubernetes Pod ({KubernetesServiceHost} and/or {KubernetesServicePort} environment variable is not defined).");
+                throw new InvalidOperationException($"KubeApiClient.CreateFromPodServiceAccount can only be called when running in a Kubernetes Pod ({KubeClientConstants.KubernetesServiceHost} and/or {KubeClientConstants.KubernetesServicePort} environment variable is not defined).");
 
             string apiEndPoint = $"https://{kubeServiceHost}:{kubeServicePort}/";
             string accessToken = File.ReadAllText(Path.Combine(serviceAccountPath, "token"));

--- a/src/KubeClient/KubeClientOptions.cs
+++ b/src/KubeClient/KubeClientOptions.cs
@@ -13,6 +13,16 @@ namespace KubeClient
     public class KubeClientOptions
     {
         /// <summary>
+        /// Environment Variable set in a Kubernetes Pod containing the host name of the API Service
+        /// </summary>
+        public const string KubernetesServiceHost = "KUBERNETES_SERVICE_HOST";
+        
+        /// <summary>
+        /// Environment Variable set in a Kubernetes Pod containing the port of the API Service
+        /// </summary>
+        public const string KubernetesServicePort = "KUBERNETES_SERVICE_PORT";
+        
+        /// <summary>
         ///     Create new <see cref="KubeClientOptions"/>.
         /// </summary>
         public KubeClientOptions()
@@ -189,10 +199,10 @@ namespace KubeClient
         /// </remarks>
         public static KubeClientOptions FromPodServiceAccount()
         {
-            string kubeServiceHost = Environment.GetEnvironmentVariable("KUBERNETES_SERVICE_HOST");
-            string kubeServicePort = Environment.GetEnvironmentVariable("KUBERNETES_SERVICE_PORT");
+            string kubeServiceHost = Environment.GetEnvironmentVariable(KubernetesServiceHost);
+            string kubeServicePort = Environment.GetEnvironmentVariable(KubernetesServicePort);
             if (String.IsNullOrWhiteSpace(kubeServiceHost) || String.IsNullOrWhiteSpace(kubeServicePort))
-                throw new InvalidOperationException("KubeApiClient.CreateFromPodServiceAccount can only be called when running in a Kubernetes Pod (KUBERNETES_SERVICE_HOST and/or KUBERNETES_SERVICE_PORT environment variable is not defined).");
+                throw new InvalidOperationException($"KubeApiClient.CreateFromPodServiceAccount can only be called when running in a Kubernetes Pod ({KubernetesServiceHost} and/or {KubernetesServicePort} environment variable is not defined).");
 
             string apiEndPoint = $"https://{kubeServiceHost}:{kubeServicePort}/";
             string accessToken = File.ReadAllText("/var/run/secrets/kubernetes.io/serviceaccount/token");

--- a/src/KubeClient/MessageHandlers/BasicAuthenticationHandler.cs
+++ b/src/KubeClient/MessageHandlers/BasicAuthenticationHandler.cs
@@ -29,7 +29,8 @@ namespace KubeClient.MessageHandlers
 
             _encoded = Convert.ToBase64String(Encoding.ASCII.GetBytes(username + ":" + password));
         }
-        
+
+        /// <inheritdoc />
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             request.Headers.Authorization = new AuthenticationHeaderValue("Basic", _encoded);


### PR DESCRIPTION
Add an optional parameter to `KubeClientOptions.FromPodServiceAccount` to allow callers to override the serviceAccountPath.  Useful for Telepresence support where the service account volume is not mounted in the default location ([docs](https://www.telepresence.io/howto/volumes)).  Also moves the environment variables and defaults to constant properties, so callers can use those.

Resolves #118 

Also added an `<inheritdoc />` for some code I had submitted previously without it.  Oops.

A caller can now use the following to support running inside a Telepresence container:
```c#
var telepresenceRoot = Environment.GetEnvironmentVariable("TELEPRESENCE_ROOT");
var kubeOptions = String.IsNullOrEmpty(telepresenceRoot)
    ? KubeClientOptions.FromPodServiceAccount()
    : KubeClientOptions.FromPodServiceAccount(telepresenceRoot + KubeClientOptions.DefaultServiceAccountPath);
```


Signed-off-by: Jon Stelly <967068+jonstelly@users.noreply.github.com>