### PR TITLE
Use of lower case to Create resource in Dynamic Client

### DIFF
--- a/src/KubeClient/ResourceClients/DynamicResourceClient.cs
+++ b/src/KubeClient/ResourceClients/DynamicResourceClient.cs
@@ -313,7 +313,7 @@ namespace KubeClient.ResourceClients
             {
                 request = request.WithTemplateParameters(new
                 {
-                    Namespace = resource.Metadata?.Namespace ?? KubeClient.DefaultNamespace
+                    @namespace = resource.Metadata?.Namespace ?? KubeClient.DefaultNamespace
                 });
             }
 


### PR DESCRIPTION
Fixes #126 

This will fix the creation of resources when using the Dynamic Resource Client. An annonymous object was created with a single property 'Namespace' - with a capital "N", but the Post method expected a property 'namespace' - with a lower case "n".