### PR TITLE
Add DI registration methods for named KubeClientOptions from pod service account

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -15,6 +15,8 @@ branches:
     track-merge-target: false
     tracks-release-branches: false
     is-release-branch: false
+    is-mainline: true
+    source-branches: [ 'develop' ]
 
   develop:
     regex: develop
@@ -25,8 +27,7 @@ branches:
     track-merge-target: true
     tracks-release-branches: true
     is-release-branch: false
-    is-source-branch-for:
-      - master
+    source-branches: [ 'feature' ]
 
   feature:
     mode: ContinuousDeployment
@@ -35,8 +36,6 @@ branches:
     increment: Minor
     prevent-increment-of-merged-branch-version: false
     track-merge-target: false
-    is-source-branch-for:
-      - develop
 
   pull-request:
     regex: (pull|pull\-request|pr)[/-]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ steps:
   
   inputs:
     command: 'restore'
-    projects: './KubeClient.sln'
+    projects: '$(Build.SourcesDirectory)/KubeClient.sln'
     restoreArguments: '/p:VersionPrefix="$(GitVersion.MajorMinorPatch)" /p:VersionSuffix="$(GitVersion.PreReleaseTag)"'
 
 - task: DotNetCoreCLI@2
@@ -44,7 +44,7 @@ steps:
   
   inputs:
     command: 'build'
-    projects: './test/*.Tests/*.Tests.csproj'
+    projects: '$(Build.SourcesDirectory)/KubeClient.sln'
     arguments: '--configuration "$(buildConfiguration)" /p:VersionPrefix="$(GitVersion.MajorMinorPatch)" /p:VersionSuffix="$(GitVersion.PreReleaseTag)"'
 
 - task: DotNetCoreCLI@2
@@ -52,7 +52,7 @@ steps:
   
   inputs:
     command: 'test'
-    projects: './KubeClient.sln'
+    projects: '$(Build.SourcesDirectory)/test/KubeClient.*.Tests/*.csproj'
     arguments: '--configuration "$(buildConfiguration)" /p:VersionPrefix="$(GitVersion.MajorMinorPatch)" /p:VersionSuffix="$(GitVersion.PreReleaseTag)"'
 
 - task: DotNetCoreCLI@2
@@ -60,7 +60,7 @@ steps:
   
   inputs:
     command: 'pack'
-    projects: './KubeClient.sln'
+    projects: '$(Build.SourcesDirectory)/KubeClient.sln'
     arguments: '--configuration "$(buildConfiguration)" -o "$(Build.ArtifactStagingDirectory)" /p:VersionPrefix="$(GitVersion.MajorMinorPatch)" /p:VersionSuffix="$(GitVersion.PreReleaseTag)"'
     modifyOutputPath: false
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,14 +61,14 @@ steps:
   inputs:
     command: 'pack'
     projects: '$(Build.SourcesDirectory)/KubeClient.sln'
-    arguments: '--configuration "$(buildConfiguration)" -o "$(Build.ArtifactStagingDirectory)" /p:VersionPrefix="$(GitVersion.MajorMinorPatch)" /p:VersionSuffix="$(GitVersion.PreReleaseTag)"'
+    arguments: '--configuration "$(buildConfiguration)" -o "$(Build.ArtifactStagingDirectory)/packages" /p:VersionPrefix="$(GitVersion.MajorMinorPatch)" /p:VersionSuffix="$(GitVersion.PreReleaseTag)"'
     modifyOutputPath: false
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish packages as artifact'
   
   inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)/*.nupkg'
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)/packages'
     ArtifactName: 'packages'
     publishLocation: 'Container'
 
@@ -85,5 +85,5 @@ steps:
     tagSource: 'gitTag'
     tagPattern: '^v\d+\.\d+.\d+(-[A-Za-z0-9%\.]+)?$'
     addChangeLog: true
-    assets: '$(Build.ArtifactStagingDirectory)/*.nupkg'
+    assets: '$(Build.ArtifactStagingDirectory)/packages/*.nupkg'
     assetUploadMode: replace

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,6 +31,13 @@ steps:
   displayName: 'Determine build version'
   name: GitVersion
 
+- script: |
+    BUILD_SEMVER="$(GitVersion.FullSemVer)"
+    
+    echo "##vso[task.setvariable variable=BUILD_SEMVER]$BUILD_SEMVER"
+    echo "BUILD_SEMVER='$BUILD_SEMVER'"
+  displayName: Set environment variables from build version
+
 - task: DotNetCoreCLI@2
   displayName: 'Restore packages'
   
@@ -61,8 +68,11 @@ steps:
   inputs:
     command: 'pack'
     projects: '$(Build.SourcesDirectory)/KubeClient.sln'
-    arguments: '--configuration "$(buildConfiguration)" /p:VersionPrefix="$(GitVersion.MajorMinorPatch)" /p:VersionSuffix="$(GitVersion.PreReleaseTag)"'
+
+    arguments: '--configuration "$(buildConfiguration)"'
     outputDir: '$(Build.ArtifactStagingDirectory)/packages'
+    versioningScheme: byEnvVar
+    versionEnvVar: BUILD_SEMVER
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish packages as artifact'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,8 +61,8 @@ steps:
   inputs:
     command: 'pack'
     projects: '$(Build.SourcesDirectory)/KubeClient.sln'
-    arguments: '--configuration "$(buildConfiguration)" -o "$(Build.ArtifactStagingDirectory)/packages" /p:VersionPrefix="$(GitVersion.MajorMinorPatch)" /p:VersionSuffix="$(GitVersion.PreReleaseTag)"'
-    modifyOutputPath: false
+    arguments: '--configuration "$(buildConfiguration)" /p:VersionPrefix="$(GitVersion.MajorMinorPatch)" /p:VersionSuffix="$(GitVersion.PreReleaseTag)"'
+    outputDir: '$(Build.ArtifactStagingDirectory)/packages'
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish packages as artifact'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,8 @@ trigger:
   branches:
     include:
       - master
+      - develop
+      - release/*
 
   tags:
     include:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,87 @@
+trigger:
+  branches:
+    include:
+      - master
+
+  tags:
+    include:
+      - 'v*'
+
+pr:
+  branches:
+    include:
+      - master
+
+pool:
+  vmImage: ubuntu-latest
+
+variables:
+  buildConfiguration: 'Release'
+
+steps:
+- task: gitversion/setup@0
+  displayName: 'Install GitVersion'
+
+  inputs:
+   versionSpec: 5.x
+
+- task: GitVersion/execute@0
+  displayName: 'Determine build version'
+  name: GitVersion
+
+- task: DotNetCoreCLI@2
+  displayName: 'Restore packages'
+  
+  inputs:
+    command: 'restore'
+    projects: './KubeClient.sln'
+    restoreArguments: '/p:VersionPrefix="$(GitVersion.MajorMinorPatch)" /p:VersionSuffix="$(GitVersion.PreReleaseTag)"'
+
+- task: DotNetCoreCLI@2
+  displayName: 'Build solution'
+  
+  inputs:
+    command: 'build'
+    projects: './KubeClient.sln'
+    arguments: '--configuration "$(buildConfiguration)" /p:VersionPrefix="$(GitVersion.MajorMinorPatch)" /p:VersionSuffix="$(GitVersion.PreReleaseTag)"'
+
+- task: DotNetCoreCLI@2
+  displayName: 'Run tests'
+  
+  inputs:
+    command: 'test'
+    projects: './KubeClient.sln'
+    arguments: '--configuration "$(buildConfiguration)" /p:VersionPrefix="$(GitVersion.MajorMinorPatch)" /p:VersionSuffix="$(GitVersion.PreReleaseTag)"'
+
+- task: DotNetCoreCLI@2
+  displayName: 'Create packages'
+  
+  inputs:
+    command: 'pack'
+    projects: './KubeClient.sln'
+    arguments: '--configuration "$(buildConfiguration)" -o "$(Build.ArtifactStagingDirectory)" /p:VersionPrefix="$(GitVersion.MajorMinorPatch)" /p:VersionSuffix="$(GitVersion.PreReleaseTag)"'
+    modifyOutputPath: false
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish packages as artifact'
+  
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)/*.nupkg'
+    ArtifactName: 'packages'
+    publishLocation: 'Container'
+
+- task: GitHubRelease@1
+  displayName: 'Create GitHub release from tag'
+
+  condition: contains(variables['Build.SourceBranch'], 'refs/tags/v')
+  
+  inputs:
+    gitHubConnection: 'github.com_tintoy'
+    repositoryName: '$(Build.Repository.Name)'
+    action: 'create'
+    target: '$(Build.SourceVersion)'
+    tagSource: 'gitTag'
+    tagPattern: '^v\d+\.\d+.\d+(-[A-Za-z0-9%\.]+)?$'
+    addChangeLog: true
+    assets: '$(Build.ArtifactStagingDirectory)/*.nupkg'
+    assetUploadMode: replace

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ steps:
   
   inputs:
     command: 'build'
-    projects: './KubeClient.sln'
+    projects: './test/*.Tests/*.Tests.csproj'
     arguments: '--configuration "$(buildConfiguration)" /p:VersionPrefix="$(GitVersion.MajorMinorPatch)" /p:VersionSuffix="$(GitVersion.PreReleaseTag)"'
 
 - task: DotNetCoreCLI@2

--- a/src/KubeClient.Extensions.DependencyInjection/ClientRegistrationExtensions.cs
+++ b/src/KubeClient.Extensions.DependencyInjection/ClientRegistrationExtensions.cs
@@ -155,41 +155,6 @@ namespace KubeClient
         }
 
         /// <summary>
-        ///     Add named <see cref="KubeClientOptions"/> to the service collection.
-        /// </summary>
-        /// <param name="services">
-        ///     The service collection to configure.
-        /// </param>
-        /// <param name="name">
-        ///     A name used to resolve the options.
-        /// </param>
-        /// <param name="configure">
-        ///     A delegate that performs required configuration of the <see cref="KubeClientOptions"/>.
-        /// </param>
-        /// <returns>
-        ///     The configured service collection.
-        /// </returns>
-        public static IServiceCollection AddKubeClientOptions(this IServiceCollection services, string name, Action<KubeClientOptions> configure)
-        {
-            if (services == null)
-                throw new ArgumentNullException(nameof(services));
-
-            if (String.IsNullOrWhiteSpace(name))
-                throw new ArgumentException("Argument cannot be null, empty, or entirely composed of whitespace: 'name'.", nameof(name));
-
-            if (configure == null)
-                throw new ArgumentNullException(nameof(configure));
-            
-            services.Configure<KubeClientOptions>(name, options =>
-            {
-                configure(options);
-                options.EnsureValid();
-            });
-
-            return services;
-        }
-
-        /// <summary>
         ///     Add support for named Kubernetes client instances.
         /// </summary>
         /// <param name="services">

--- a/src/KubeClient.Extensions.DependencyInjection/KubeClientOptionsRegistrationExtensions.cs
+++ b/src/KubeClient.Extensions.DependencyInjection/KubeClientOptionsRegistrationExtensions.cs
@@ -13,6 +13,70 @@ namespace KubeClient
     public static class KubeClientOptionsRegistrationExtensions
     {
         /// <summary>
+        ///     Add <see cref="KubeClientOptions"/> to the service collection.
+        /// </summary>
+        /// <param name="services">
+        ///     The service collection to configure.
+        /// </param>
+        /// <param name="configure">
+        ///     A delegate that performs required configuration of the <see cref="KubeClientOptions"/>.
+        /// </param>
+        /// <returns>
+        ///     The configured service collection.
+        /// </returns>
+        public static IServiceCollection AddKubeClientOptions(this IServiceCollection services, Action<KubeClientOptions> configure)
+        {
+            if (services == null)
+                throw new ArgumentNullException(nameof(services));
+
+            if (configure == null)
+                throw new ArgumentNullException(nameof(configure));
+
+            services.Configure<KubeClientOptions>(options =>
+            {
+                configure(options);
+                options.EnsureValid();
+            });
+
+            return services;
+        }
+
+        /// <summary>
+        ///     Add named <see cref="KubeClientOptions"/> to the service collection.
+        /// </summary>
+        /// <param name="services">
+        ///     The service collection to configure.
+        /// </param>
+        /// <param name="name">
+        ///     A name used to resolve the options.
+        /// </param>
+        /// <param name="configure">
+        ///     A delegate that performs required configuration of the <see cref="KubeClientOptions"/>.
+        /// </param>
+        /// <returns>
+        ///     The configured service collection.
+        /// </returns>
+        public static IServiceCollection AddKubeClientOptions(this IServiceCollection services, string name, Action<KubeClientOptions> configure)
+        {
+            if (services == null)
+                throw new ArgumentNullException(nameof(services));
+
+            if (String.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("Argument cannot be null, empty, or entirely composed of whitespace: 'name'.", nameof(name));
+
+            if (configure == null)
+                throw new ArgumentNullException(nameof(configure));
+
+            services.Configure<KubeClientOptions>(name, options =>
+            {
+                configure(options);
+                options.EnsureValid();
+            });
+
+            return services;
+        }
+
+        /// <summary>
         ///     Add <see cref="KubeClientOptions"/> from local Kubernetes client configuration.
         /// </summary>
         /// <param name="services">
@@ -207,6 +271,60 @@ namespace KubeClient
                     kubeClientOptions.AccessToken = targetUser.Config.GetRawToken();
                 });
             }
+
+            return services;
+        }
+
+        /// <summary>
+        ///     Add <see cref="KubeClientOptions"/> from the pod service account.
+        /// </summary>
+        /// <param name="services">
+        ///     The service collection to configure.
+        /// </param>
+        /// <returns>
+        ///     The configured service collection.
+        /// </returns>
+        public static IServiceCollection AddKubeClientOptionsFromPodServiceAccount(this IServiceCollection services)
+        {
+            if (services == null)
+                throw new ArgumentNullException(nameof(services));
+
+            services.AddKubeClientOptions(kubeClientOptions =>
+            {
+                KubeClientOptions fromPodServiceAccount = KubeClientOptions.FromPodServiceAccount();
+
+                fromPodServiceAccount.CopyTo(kubeClientOptions);
+            });
+
+            return services;
+        }
+
+        /// <summary>
+        ///     Add named <see cref="KubeClientOptions"/> from the pod service account.
+        /// </summary>
+        /// <param name="services">
+        ///     The service collection to configure.
+        /// </param>
+        /// <param name="name">
+        ///     The name used to resolve these options.
+        /// </param>
+        /// <returns>
+        ///     The configured service collection.
+        /// </returns>
+        public static IServiceCollection AddKubeClientOptionsFromPodServiceAccount(this IServiceCollection services, string name)
+        {
+            if (services == null)
+                throw new ArgumentNullException(nameof(services));
+
+            if (String.IsNullOrWhiteSpace(name))
+                throw new ArgumentException($"Argument cannot be null, empty, or entirely composed of whitespace: {nameof(name)}.", nameof(name));
+
+            services.AddKubeClientOptions(name, kubeClientOptions =>
+            {
+                KubeClientOptions fromPodServiceAccount = KubeClientOptions.FromPodServiceAccount();
+
+                fromPodServiceAccount.CopyTo(kubeClientOptions);
+            });
 
             return services;
         }

--- a/src/KubeClient/KubeClientOptions.cs
+++ b/src/KubeClient/KubeClientOptions.cs
@@ -134,34 +134,49 @@ namespace KubeClient
         public Dictionary<string, string> EnvironmentVariables { get; set; }
 
         /// <summary>
-        /// Create a copy of the <see cref="KubeClientOptions"/>.
+        ///     Create a copy of the <see cref="KubeClientOptions"/>.
         /// </summary>
-        /// <returns>The new <see cref="KubeClientOptions"/>.</returns>
+        /// <returns>
+        ///     The new <see cref="KubeClientOptions"/>.
+        /// </returns>
         public KubeClientOptions Clone()
         {
-            var clonedOptions = new KubeClientOptions
-            {
-                AccessToken = AccessToken,
-                AccessTokenCommand = AccessTokenCommand,
-                AccessTokenCommandArguments = AccessTokenCommandArguments,
-                AccessTokenExpirySelector = AccessTokenExpirySelector,
-                AccessTokenSelector = AccessTokenSelector,
-                AllowInsecure = AllowInsecure,
-                ApiEndPoint = ApiEndPoint,
-                AuthStrategy = AuthStrategy,
-                CertificationAuthorityCertificate = CertificationAuthorityCertificate,
-                ClientCertificate = ClientCertificate,
-                InitialAccessToken = InitialAccessToken,
-                InitialTokenExpiryUtc = InitialTokenExpiryUtc,
-                KubeNamespace = KubeNamespace,
-                LoggerFactory = LoggerFactory,
-                LogHeaders = LogHeaders,
-                LogPayloads = LogPayloads,
-                EnvironmentVariables = EnvironmentVariables
-            };
-            clonedOptions.ModelTypeAssemblies.AddRange(ModelTypeAssemblies);
-
+            var clonedOptions = new KubeClientOptions();
+            
+            CopyTo(clonedOptions);
+            
             return clonedOptions;
+        }
+
+        /// <summary>
+        ///     Copy all properties from the <see cref="KubeClientOptions"/> to other <see cref="KubeClientOptions"/>.
+        /// </summary>
+        /// <param name="toOptions">
+        ///     The target <see cref="KubeClientOptions"/>.
+        /// </param>
+        public void CopyTo(KubeClientOptions toOptions)
+        {
+            if (toOptions == null)
+                throw new ArgumentNullException(nameof(toOptions));
+
+            toOptions.AccessToken = AccessToken;
+            toOptions.AccessTokenCommand = AccessTokenCommand;
+            toOptions.AccessTokenCommandArguments = AccessTokenCommandArguments;
+            toOptions.AccessTokenExpirySelector = AccessTokenExpirySelector;
+            toOptions.AccessTokenSelector = AccessTokenSelector;
+            toOptions.AllowInsecure = AllowInsecure;
+            toOptions.ApiEndPoint = ApiEndPoint;
+            toOptions.AuthStrategy = AuthStrategy;
+            toOptions.CertificationAuthorityCertificate = CertificationAuthorityCertificate;
+            toOptions.ClientCertificate = ClientCertificate;
+            toOptions.InitialAccessToken = InitialAccessToken;
+            toOptions.InitialTokenExpiryUtc = InitialTokenExpiryUtc;
+            toOptions.KubeNamespace = KubeNamespace;
+            toOptions.LoggerFactory = LoggerFactory;
+            toOptions.LogHeaders = LogHeaders;
+            toOptions.LogPayloads = LogPayloads;
+            toOptions.EnvironmentVariables = EnvironmentVariables;
+            toOptions.ModelTypeAssemblies.AddRange(ModelTypeAssemblies);
         }
 
         /// <summary>

--- a/test/KubeClient.Extensions.WebSockets.Tests/TestBase.cs
+++ b/test/KubeClient.Extensions.WebSockets.Tests/TestBase.cs
@@ -50,7 +50,7 @@ namespace KubeClient.Extensions.WebSockets.Tests
             Assert.True(CurrentTest != null, "Cannot retrieve current test from ITestOutputHelper.");
 
             Disposal.Add(
-                Log.BeginScope("CurrentTest", CurrentTest.DisplayName)
+                Log.BeginScope("CurrentTest {CurrentTest}", CurrentTest.DisplayName)
             );
         }
 


### PR DESCRIPTION
Note: this change breaks binary compatibility because of refactoring that moves an extension method to live in the same class as other (related) extension methods.