### PR TITLE
Implement automatic retry of watch streams that terminate without any error

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status (Travis CI)](https://travis-ci.org/tintoy/dotnet-kube-client.svg?branch=develop)](https://travis-ci.org/tintoy/dotnet-kube-client)
 
-KubeClient is an extensible Kubernetes API client for .NET Core (targets `netstandard1.4`).
+KubeClient is an extensible Kubernetes API client for .NET Core (targets `netstandard2.0`).
 
 Note - there is also an [official](https://github.com/kubernetes-client/csharp/) .NET client for Kubernetes (both clients actually share code in a couple of places). These two clients are philosophically-different (from a design perspective) but either can be bent to fit your needs. For more information about how KubeClient differs from the official client, see the section below on [extensibility](#extensibility).
 
@@ -12,7 +12,7 @@ Note - there is also an [official](https://github.com/kubernetes-client/csharp/)
 
 ## Packages
 
-* `KubeClient` (`netstandard1.4` or newer)    
+* `KubeClient` (`netstandard2.0` or newer)    
   The main client and models.  
   [![KubeClient](https://img.shields.io/nuget/v/KubeClient.svg)](https://www.nuget.org/packages/KubeClient)
 * `KubeClient.Extensions.Configuration` (`netstandard2.0` or newer)  
@@ -21,7 +21,7 @@ Note - there is also an [official](https://github.com/kubernetes-client/csharp/)
 * `KubeClient.Extensions.DependencyInjection` (`netstandard2.0` or newer)  
   Dependency-injection support.  
   [![KubeClient.Extensions.KubeConfig](https://img.shields.io/nuget/v/KubeClient.Extensions.DependencyInjection.svg)](https://www.nuget.org/packages/KubeClient.Extensions.DependencyInjection)  
-* `KubeClient.Extensions.KubeConfig` (`netstandard1.4` or newer)  
+* `KubeClient.Extensions.KubeConfig` (`netstandard2.0` or newer)  
   Support for loading and parsing configuration from `~/.kube/config`.  
   [![KubeClient.Extensions.KubeConfig](https://img.shields.io/nuget/v/KubeClient.Extensions.KubeConfig.svg)](https://www.nuget.org/packages/KubeClient.Extensions.KubeConfig)
 * `KubeClient.Extensions.WebSockets` (`netstandard2.1` or newer)  

--- a/samples/WatchEvents/WatchEvents.csproj
+++ b/samples/WatchEvents/WatchEvents.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.0" />
-    <PackageReference Include="System.Reactive" Version="3.1.1" />
+    <PackageReference Include="System.Reactive" Version="4.4.1" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
   </ItemGroup>
 </Project>

--- a/src/KubeClient.Extensions.Configuration/KubeClient.Extensions.Configuration.csproj
+++ b/src/KubeClient.Extensions.Configuration/KubeClient.Extensions.Configuration.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
-      <PackageReference Include="System.Reactive" Version="3.1.1" />
+      <PackageReference Include="System.Reactive" Version="4.4.1" />
   </ItemGroup>
 
   <Import Project="..\Common.props" />

--- a/src/KubeClient.Extensions.KubeConfig/KubeClient.Extensions.KubeConfig.csproj
+++ b/src/KubeClient.Extensions.KubeConfig/KubeClient.Extensions.KubeConfig.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
 
     <Description>Kubernetes client configuration support for KubeClient</Description>
   </PropertyGroup>
@@ -14,7 +14,7 @@
       <PackageReference Include="HTTPlease.Core" Version="$(PackageVersion_HTTPlease)" />
       <PackageReference Include="BouncyCastle.NetCore" Version="1.8.1.3" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-      <PackageReference Include="System.Reactive" Version="3.1.1" />
+      <PackageReference Include="System.Reactive" Version="4.4.1" />
       <PackageReference Include="YamlDotNet" Version="6.1.2" />
   </ItemGroup>
 

--- a/src/KubeClient/KubeApiException.cs
+++ b/src/KubeClient/KubeApiException.cs
@@ -1,6 +1,12 @@
 using HTTPlease;
 using System;
 
+#if NETSTANDARD2_0
+
+using System.Runtime.Serialization;
+
+#endif // NETSTANDARD2_0
+
 namespace KubeClient
 {
     using Models;
@@ -8,9 +14,9 @@ namespace KubeClient
     /// <summary>
     ///     Exception raised when an error result is returned by the Kubernetes API.
     /// </summary>
-#if NETSTANDARD20
+#if NETSTANDARD2_0
     [Serializable]
-#endif // NETSTANDARD20
+#endif // NETSTANDARD2_0
     public class KubeApiException
         : KubeClientException
     {
@@ -106,7 +112,7 @@ namespace KubeClient
         /// <param name="context">
         ///     A <see cref="StreamingContext"/> containing information about the origin of the serialised data.
         /// </param>
-        protected KubeClientException(SerializationInfo info, StreamingContext context)
+        protected KubeApiException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }

--- a/src/KubeClient/KubeClient.csproj
+++ b/src/KubeClient/KubeClient.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
 
     <Description>A Kubernetes API client for .NET</Description>
   </PropertyGroup>
@@ -12,7 +12,7 @@
       <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="1.1.2" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
       <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-      <PackageReference Include="System.Reactive" Version="3.1.1" />
+      <PackageReference Include="System.Reactive" Version="4.4.1" />
       <PackageReference Include="System.ValueTuple" Version="4.4.0" />
       <PackageReference Include="YamlDotNet" Version="6.1.2" />
   </ItemGroup>

--- a/src/KubeClient/KubeClientException.cs
+++ b/src/KubeClient/KubeClientException.cs
@@ -1,6 +1,12 @@
 using HTTPlease;
 using System;
 
+#if NETSTANDARD2_0
+
+using System.Runtime.Serialization;
+
+#endif // NETSTANDARD2_0
+
 namespace KubeClient
 {
     using Models;

--- a/src/KubeClient/ResourceClients/KubeResourceClient.cs
+++ b/src/KubeClient/ResourceClients/KubeResourceClient.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
 using System.Linq;
@@ -14,14 +15,13 @@ using System.Reactive.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
-using Newtonsoft.Json.Serialization;
 
 namespace KubeClient.ResourceClients
 {
     using KubeClient.Models.ContractResolvers;
     using Models;
     using Models.Converters;
+    using System.Reactive;
 
     /// <summary>
     ///     The base class for Kubernetes resource API clients.
@@ -29,6 +29,11 @@ namespace KubeClient.ResourceClients
     public abstract class KubeResourceClient
         : IKubeResourceClient
     {
+        /// <summary>
+        ///     The default even
+        /// </summary>
+        public static readonly EventId DefaultEventId = new EventId(8500, typeof(KubeResourceClient).FullName);
+
         /// <summary>
         ///     The default buffer size to use when streaming data from the Kubernetes API.
         /// </summary>
@@ -93,7 +98,7 @@ namespace KubeClient.ResourceClients
         {
             if (client == null)
                 throw new ArgumentNullException(nameof(client));
-            
+
             KubeClient = client;
         }
 
@@ -137,7 +142,7 @@ namespace KubeClient.ResourceClients
         {
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
-            
+
             using (HttpResponseMessage responseMessage = await Http.GetAsync(request, cancellationToken).ConfigureAwait(false))
             {
                 if (responseMessage.IsSuccessStatusCode)
@@ -183,7 +188,7 @@ namespace KubeClient.ResourceClients
         {
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
-            
+
             using (HttpResponseMessage responseMessage = await Http.GetAsync(request, cancellationToken).ConfigureAwait(false))
             {
                 if (responseMessage.IsSuccessStatusCode)
@@ -227,13 +232,13 @@ namespace KubeClient.ResourceClients
         {
             if (patchAction == null)
                 throw new ArgumentNullException(nameof(patchAction));
-            
+
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
 
             // If possible, tell the consumer which resource type we had a problem with (helpful when all you find is the error message in the log).
             (string kind, string apiVersion) = KubeObjectV1.GetKubeKind<TResource>();
-            
+
             var patch = new JsonPatchDocument<TResource>();
 
             patchAction(patch);
@@ -273,13 +278,13 @@ namespace KubeClient.ResourceClients
         {
             if (patchAction == null)
                 throw new ArgumentNullException(nameof(patchAction));
-            
+
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
 
             // If possible, tell the consumer which resource type we had a problem with (helpful when all you find is the error message in the log).
             (string kind, string apiVersion) = KubeObjectV1.GetKubeKind<TResource>();
-            
+
             var patch = new JsonPatchDocument();
             patchAction(patch);
 
@@ -324,13 +329,13 @@ namespace KubeClient.ResourceClients
         {
             if (resourceByNameRequestTemplate == null)
                 throw new ArgumentNullException(nameof(resourceByNameRequestTemplate));
-            
+
             if (String.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("Argument cannot be null, empty, or entirely composed of whitespace: 'name'.", nameof(name));
 
             if (String.IsNullOrWhiteSpace(kubeNamespace))
                 kubeNamespace = KubeClient.DefaultNamespace;
-            
+
             var response = Http.DeleteAsJsonAsync(
                 resourceByNameRequestTemplate.WithTemplateParameters(new
                 {
@@ -376,7 +381,7 @@ namespace KubeClient.ResourceClients
         {
             if (resourceByNameNoNamespaceRequestTemplate == null)
                 throw new ArgumentNullException(nameof(resourceByNameNoNamespaceRequestTemplate));
-            
+
             if (String.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("Argument cannot be null, empty, or entirely composed of whitespace: 'name'.", nameof(name));
 
@@ -424,13 +429,34 @@ namespace KubeClient.ResourceClients
 
             JsonSerializerSettings serializerSettings = request.GetFormatters().Values.GetJsonSerializerSettings();
 
-            return ObserveLines(request, operationDescription)
+            ILogger logger = LoggerFactory.CreateLogger(GetType());
+
+            // If we have already observed any events, we only want to see ones newer than the last one we have seen so far.
+            string lastObservedResourceVersion = null;
+
+            return
+                ObserveLinesWithRetry(operationDescription,
+                    requestFactory: () =>
+                    {
+                        HttpRequest currentRequest = request;
+
+                        if (!String.IsNullOrWhiteSpace(lastObservedResourceVersion))
+                            currentRequest = currentRequest.WithQueryParameter("resourceVersion", lastObservedResourceVersion);
+
+                        return currentRequest;
+                    },
+                    shouldRetry: exception => exception == null // Only retry if there was no exception
+                )
                 .Do(
                     line => CheckForEventError(line, operationDescription)
                 )
                 .Select(
-                    line => (IResourceEventV1<TResource>) JsonConvert.DeserializeObject<ResourceEventV1<TResource>>(line, serializerSettings)
-                );
+                    line => (IResourceEventV1<TResource>)JsonConvert.DeserializeObject<ResourceEventV1<TResource>>(line, serializerSettings)
+                )
+                .Do(resourceEvent =>
+                {
+                    lastObservedResourceVersion = resourceEvent.Resource.Metadata.ResourceVersion;
+                });
         }
 
         /// <summary>
@@ -462,8 +488,25 @@ namespace KubeClient.ResourceClients
                     KubeClient.GetClientOptions().ModelTypeAssemblies
                 )
             );
-            
-            return ObserveLines(request, operationDescription)
+
+            ILogger logger = LoggerFactory.CreateLogger(GetType());
+
+            // If we have already observed any events, we only want to see ones newer than the last one we have seen so far.
+            string lastObservedResourceVersion = null;
+
+            return
+                ObserveLinesWithRetry(operationDescription,
+                    requestFactory: () =>
+                    {
+                        HttpRequest currentRequest = request;
+
+                        if (!String.IsNullOrWhiteSpace(lastObservedResourceVersion))
+                            currentRequest = currentRequest.WithQueryParameter("resourceVersion", lastObservedResourceVersion);
+
+                        return currentRequest;
+                    },
+                    shouldRetry: exception => exception == null // Only retry if there was no exception
+                )
                 .Do(
                     line => CheckForEventError(line, operationDescription)
                 )
@@ -478,6 +521,10 @@ namespace KubeClient.ResourceClients
                     }
 
                     return resourceEvent;
+                })
+                .Do(resourceEvent =>
+                {
+                    lastObservedResourceVersion = resourceEvent.Resource.Metadata.ResourceVersion;
                 });
         }
 
@@ -505,12 +552,52 @@ namespace KubeClient.ResourceClients
 
             if (String.IsNullOrWhiteSpace(operationDescription))
                 throw new ArgumentException("Argument cannot be null, empty, or entirely composed of whitespace: 'operationDescription'.", nameof(operationDescription));
+
+            return ObserveLines(
+                requestFactory: () => request,
+                operationDescription,
+                bufferSize
+            );
+        }
+
+        /// <summary>
+        ///     Get an <see cref="IObservable{T}"/> for lines streamed from an HTTP GET request.
+        /// </summary>
+        /// <param name="requestFactory">
+        ///     A delegate that produces the <see cref="HttpRequest"/> to execute.
+        /// </param>
+        /// <param name="operationDescription">
+        ///     A short description of the operation (used in error messages if the request fails).
+        /// </param>
+        /// <param name="bufferSize">
+        ///     The buffer size to use when streaming data.
+        /// 
+        ///     Default is 2048 bytes.
+        /// </param>
+        /// <returns>
+        ///     The <see cref="IObservable{T}"/>.
+        /// </returns>
+        protected IObservable<string> ObserveLines(Func<HttpRequest> requestFactory, string operationDescription, int bufferSize = DefaultStreamingBufferSize)
+        {
+            if (requestFactory == null)
+                throw new ArgumentNullException(nameof(requestFactory));
+
+            if (String.IsNullOrWhiteSpace(operationDescription))
+                throw new ArgumentException("Argument cannot be null, empty, or entirely composed of whitespace: 'operationDescription'.", nameof(operationDescription));
             
-            return Observable.Create<string>(async (subscriber, cancellationToken) =>
+            return Observable.Create<string>(async (subscriber, subscriptionCancellationToken) =>
             {
+                // NOTE: The CancellationToken above represents the subscriber (i.e. IObserver) subscription to this sequence (i.e. IObservable), and is canceled only when their subscription is disposed.
+
+                ILogger logger = LoggerFactory.CreateLogger(GetType());
+
                 try
                 {
-                    using (HttpResponseMessage responseMessage = await Http.GetStreamedAsync(request, cancellationToken).ConfigureAwait(false))
+                    HttpRequest request = requestFactory();
+
+                    logger.LogDebug("Start streaming {RequestMethod} request for {RequestUri}...", HttpMethod.Get.Method, request.Uri.PathAndQuery);
+
+                    using (HttpResponseMessage responseMessage = await Http.GetStreamedAsync(request, subscriptionCancellationToken).ConfigureAwait(false))
                     {
                         if (!responseMessage.IsSuccessStatusCode)
                         {
@@ -533,9 +620,9 @@ namespace KubeClient.ResourceClients
                         using (Stream responseStream = await responseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false))
                         {
                             StringBuilder lineBuilder = new StringBuilder();
-                            
+
                             byte[] buffer = new byte[bufferSize];
-                            int bytesRead = await responseStream.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+                            int bytesRead = await responseStream.ReadAsync(buffer, 0, buffer.Length, subscriptionCancellationToken).ConfigureAwait(false);
                             while (bytesRead > 0)
                             {
                                 // AF: Slightly inefficient because we wind up scanning the buffer twice.
@@ -578,7 +665,7 @@ namespace KubeClient.ResourceClients
                                     }
                                 }
 
-                                bytesRead = await responseStream.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+                                bytesRead = await responseStream.ReadAsync(buffer, 0, buffer.Length, subscriptionCancellationToken).ConfigureAwait(false);
                             }
 
                             // If stream doesn't end with a line-terminator sequence, publish trailing characters as the last line.
@@ -591,31 +678,97 @@ namespace KubeClient.ResourceClients
                         }
                     }
                 }
-                catch (OperationCanceledException operationCanceled) when (operationCanceled.CancellationToken != cancellationToken)
+                catch (OperationCanceledException operationCanceled) when (operationCanceled.CancellationToken == subscriptionCancellationToken)
                 {
-                    if (!cancellationToken.IsCancellationRequested) // Don't bother publishing if subscriber has already disconnected.
-                        subscriber.OnError(operationCanceled);
+                    // Don't bother publishing if subscriber has already disconnected (this CancellationToken represents the subscription).
                 }
                 catch (HttpRequestException<StatusV1> requestError)
                 {
-                    if (!cancellationToken.IsCancellationRequested)
+                    logger.LogError(new EventId(0, "NoEventId"), requestError, "Unexpected error while streaming from the Kubernetes API to {operationDescription}.", operationDescription);
+
+                    if (!subscriptionCancellationToken.IsCancellationRequested)
                     {
                         subscriber.OnError(
-                            new KubeClientException($"Unable to {operationDescription} (unexpected error while streaming from the Kubernetes API).", requestError)
+                            new KubeClientException($"Unexpected error while streaming from the Kubernetes API to {operationDescription}.", requestError)
                         );
                     }
                 }
                 catch (Exception exception)
                 {
-                    if (!cancellationToken.IsCancellationRequested) // Don't bother publishing if subscriber has already disconnected.
+                    logger.LogError(new EventId(0, "NoEventId"), exception, "Unexpected error while streaming from the Kubernetes API to {operationDescription}.", operationDescription);
+
+                    if (!subscriptionCancellationToken.IsCancellationRequested)
                         subscriber.OnError(exception);
                 }
                 finally
                 {
-                    if (!cancellationToken.IsCancellationRequested) // Don't bother publishing if subscriber has already disconnected.
+                    if (!subscriptionCancellationToken.IsCancellationRequested) // Don't bother publishing if subscriber has already disconnected.
                         subscriber.OnCompleted();
                 }
             });
+        }
+
+        /// <summary>
+        ///     Get an <see cref="IObservable{T}"/> (with automatic retry) for lines streamed from an HTTP GET request.
+        /// </summary>
+        /// <param name="operationDescription">
+        ///     A short description of the operation (used in error messages if the request fails).
+        /// </param>
+        /// <param name="requestFactory">
+        ///     A delegate that produces the <see cref="HttpRequest"/> to execute.
+        /// </param>
+        /// <param name="shouldRetry">
+        ///     A delegate that returns <c>true</c>, if the operation should be retried (i.e. sequence continues); otherwise, <c>false</c>.
+        ///     
+        ///     <para>
+        ///         If the retry is due to successful completion of the underlying sequence of lines (<see cref="IObserver{T}.OnCompleted"/>), the exception passed to the delegate be <c>null</c>.
+        ///         If the retry is due to an exception (<see cref="IObserver{T}.OnError(Exception)"/>), the exception will be passed to the delegate.
+        ///     </para>
+        /// </param>
+        /// <param name="bufferSize">
+        ///     The buffer size to use when streaming data.
+        /// 
+        ///     Default is 2048 bytes.
+        /// </param>
+        /// <returns>
+        ///     The <see cref="IObservable{T}"/>.
+        /// </returns>
+        protected IObservable<string> ObserveLinesWithRetry(string operationDescription, Func<HttpRequest> requestFactory, Func<Exception, bool> shouldRetry, int bufferSize = DefaultStreamingBufferSize)
+        {
+            if (requestFactory == null)
+                throw new ArgumentNullException(nameof(requestFactory));
+
+            if (String.IsNullOrWhiteSpace(operationDescription))
+                throw new ArgumentException($"Argument cannot be null, empty, or entirely composed of whitespace: {nameof(operationDescription)}.", nameof(operationDescription));
+
+            if (shouldRetry == null)
+                throw new ArgumentNullException(nameof(shouldRetry));
+
+            HttpRequest currentRequest = requestFactory();
+
+            return ObserveLines(requestFactory, operationDescription, bufferSize)
+                .RetryWhen(exceptions => Observable.Create((IObserver<Unit> retrySignal, CancellationToken subscriptionCancellation) =>
+                {
+                    exceptions.Subscribe(
+                        onNext: exception =>
+                        {
+                            if (!subscriptionCancellation.IsCancellationRequested && shouldRetry(exception))
+                                retrySignal.OnNext(Unit.Default); // Retry (this will seamlessly continue the sequence).
+                            else
+                                retrySignal.OnError(exception); // Bubble up (this will terminate the sequence with an error).
+                        },
+                        onCompleted: () =>
+                        {
+                            if (!subscriptionCancellation.IsCancellationRequested && shouldRetry(null))
+                                retrySignal.OnNext(Unit.Default); // Retry (this will seamlessly continue the sequence).
+                            else
+                                retrySignal.OnCompleted(); // Bubble up (this will terminate the sequence).
+                        },
+                        subscriptionCancellation // Automatically propagate termination of subscription.
+                    );
+
+                    return Task.CompletedTask;
+                }));
         }
 
         /// <summary>

--- a/test/KubeClient.Extensions.Configuration.Tests/KubeClient.Extensions.Configuration.Tests.csproj
+++ b/test/KubeClient.Extensions.Configuration.Tests/KubeClient.Extensions.Configuration.Tests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="HTTPlease.Formatters.Json" Version="$(PackageVersion_HTTPlease)" />
     <PackageReference Include="HTTPlease.Testability.Xunit" Version="$(PackageVersion_HTTPlease)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
-    <PackageReference Include="System.Reactive" Version="3.1.1" />
+    <PackageReference Include="System.Reactive" Version="4.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/KubeClient.Extensions.DataProtection.Tests/KubeClient.Extensions.DataProtection.Tests.csproj
+++ b/test/KubeClient.Extensions.DataProtection.Tests/KubeClient.Extensions.DataProtection.Tests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="System.Reactive" Version="3.1.1" />
+    <PackageReference Include="System.Reactive" Version="4.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/KubeClient.TestCommon/KubeClient.TestCommon.csproj
+++ b/test/KubeClient.TestCommon/KubeClient.TestCommon.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
-      <PackageReference Include="System.Reactive" Version="3.1.1" />
+      <PackageReference Include="System.Reactive" Version="4.4.1" />
       <PackageReference Include="xunit" Version="2.3.1" />
   </ItemGroup>
 </Project>

--- a/test/KubeClient.Tests/KubeClient.Tests.csproj
+++ b/test/KubeClient.Tests/KubeClient.Tests.csproj
@@ -21,7 +21,7 @@
       <PackageReference Include="HTTPlease.Diagnostics" Version="$(PackageVersion_HTTPlease)" />
       <PackageReference Include="HTTPlease.Formatters.Json" Version="$(PackageVersion_HTTPlease)" />
       <PackageReference Include="HTTPlease.Testability.Xunit" Version="$(PackageVersion_HTTPlease)" />
-      <PackageReference Include="System.Reactive" Version="3.1.1" />
+      <PackageReference Include="System.Reactive" Version="4.4.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`KubeResourceClient.ObserveEvents` and `KubeResourceClient.ObserveEventsDynamic` now automatically retry the underlying HTTP request if it completes without error (which it shouldn't do unless the connection has been somehow garbage-collected, server-side). Requests that result in exceptions will still be surfaced via `IObserver<T>.OnError`.

**Note**: this change has required the library to target `netstandard2.0` (was previously targeting `netstandard1.4`). Given the age of `netstandard1.4`, this seems unlikely to affect most consumers.

Relates to #157 