### PR TITLE
Switch the BC dependency over to the official package

### DIFF
--- a/src/KubeClient.Extensions.KubeConfig/KubeClient.Extensions.KubeConfig.csproj
+++ b/src/KubeClient.Extensions.KubeConfig/KubeClient.Extensions.KubeConfig.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
       <PackageReference Include="HTTPlease.Core" Version="$(PackageVersion_HTTPlease)" />
-      <PackageReference Include="BouncyCastle.NetCore" Version="1.8.1.3" />
+      <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
       <PackageReference Include="System.Reactive" Version="4.4.1" />
       <PackageReference Include="YamlDotNet" Version="6.1.2" />


### PR DESCRIPTION
BouncyCastle has their own official nuget package - any reason we shouldn't switch over?
https://www.nuget.org/packages/BouncyCastle.Cryptography